### PR TITLE
mangle all symbols to be able to co-exist with 1.x

### DIFF
--- a/divsufsort.c
+++ b/divsufsort.c
@@ -131,7 +131,7 @@ note:
           }
         }
         if(l == 0) { break; }
-        sssort(T, PAb, SA + k, SA + l,
+        sssort_0_5_x(T, PAb, SA + k, SA + l,
                curbuf, bufsize, 2, n, *(SA + k) == (m - 1));
       }
     }
@@ -141,7 +141,7 @@ note:
       for(c1 = ALPHABET_SIZE - 1; c0 < c1; j = i, --c1) {
         i = BUCKET_BSTAR(c0, c1);
         if(1 < (j - i)) {
-          sssort(T, PAb, SA + i, SA + j,
+          sssort_0_5_x(T, PAb, SA + i, SA + j,
                  buf, bufsize, 2, n, *(SA + i) == (m - 1));
         }
       }

--- a/divsufsort.c
+++ b/divsufsort.c
@@ -335,7 +335,7 @@ construct_BWT(const sauchar_t *T, saidx_t *SA,
 /*- Function -*/
 
 saint_t
-divsufsort(const sauchar_t *T, saidx_t *SA, saidx_t n) {
+divsufsort_0_5_x(const sauchar_t *T, saidx_t *SA, saidx_t n) {
   saidx_t *bucket_A, *bucket_B;
   saidx_t m;
   saint_t err = 0;
@@ -364,7 +364,7 @@ divsufsort(const sauchar_t *T, saidx_t *SA, saidx_t n) {
 }
 
 saidx_t
-divbwt(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n) {
+divbwt_0_5_x(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n) {
   saidx_t *B;
   saidx_t *bucket_A, *bucket_B;
   saidx_t m, pidx, i;
@@ -399,6 +399,6 @@ divbwt(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n) {
 }
 
 const char *
-divsufsort_version(void) {
+divsufsort_version_0_5_x(void) {
   return PROJECT_VERSION_FULL;
 }

--- a/divsufsort.h
+++ b/divsufsort.h
@@ -73,7 +73,7 @@ typedef int32_t saidx_t;
  */
 DIVSUFSORT_API
 saint_t
-divsufsort(const sauchar_t *T, saidx_t *SA, saidx_t n);
+divsufsort_0_5_x(const sauchar_t *T, saidx_t *SA, saidx_t n);
 
 /**
  * Constructs the burrows-wheeler transformed string of a given string.
@@ -85,7 +85,7 @@ divsufsort(const sauchar_t *T, saidx_t *SA, saidx_t n);
  */
 DIVSUFSORT_API
 saidx_t
-divbwt(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n);
+divbwt_0_5_x(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n);
 
 /**
  * Returns the version of the divsufsort library.
@@ -93,7 +93,7 @@ divbwt(const sauchar_t *T, sauchar_t *U, saidx_t *A, saidx_t n);
  */
 DIVSUFSORT_API
 const char *
-divsufsort_version(void);
+divsufsort_version_0_5_x(void);
 
 
 /**

--- a/divsufsort_private.h
+++ b/divsufsort_private.h
@@ -196,7 +196,7 @@ extern "C" {
 /*- Private Prototypes -*/
 /* sssort.c */
 void
-sssort(const sauchar_t *Td, const saidx_t *PA,
+sssort_0_5_x(const sauchar_t *Td, const saidx_t *PA,
        saidx_t *first, saidx_t *last,
        saidx_t *buf, saidx_t bufsize,
        saidx_t depth, saidx_t n, saint_t lastsuffix);

--- a/error_private.h
+++ b/error_private.h
@@ -64,8 +64,8 @@ extern "C" {
 /*-****************************************
 *  Customization
 ******************************************/
-typedef ZSTD_ErrorCode ERR_enum;
-#define PREFIX(name) ZSTD_error_##name
+typedef ZSTD_0_5_X_ErrorCode ERR_enum;
+#define PREFIX(name) ZSTD_0_5_X_error_##name
 
 
 /*-****************************************

--- a/error_public.h
+++ b/error_public.h
@@ -42,23 +42,23 @@ extern "C" {
 *  error codes list
 ******************************************/
 typedef enum {
-  ZSTD_error_no_error,
-  ZSTD_error_GENERIC,
-  ZSTD_error_prefix_unknown,
-  ZSTD_error_frameParameter_unsupported,
-  ZSTD_error_frameParameter_unsupportedBy32bits,
-  ZSTD_error_init_missing,
-  ZSTD_error_memory_allocation,
-  ZSTD_error_stage_wrong,
-  ZSTD_error_dstSize_tooSmall,
-  ZSTD_error_srcSize_wrong,
-  ZSTD_error_corruption_detected,
-  ZSTD_error_tableLog_tooLarge,
-  ZSTD_error_maxSymbolValue_tooLarge,
-  ZSTD_error_maxSymbolValue_tooSmall,
-  ZSTD_error_dictionary_corrupted,
-  ZSTD_error_maxCode
-} ZSTD_ErrorCode;
+  ZSTD_0_5_X_error_no_error,
+  ZSTD_0_5_X_error_GENERIC,
+  ZSTD_0_5_X_error_prefix_unknown,
+  ZSTD_0_5_X_error_frameParameter_unsupported,
+  ZSTD_0_5_X_error_frameParameter_unsupportedBy32bits,
+  ZSTD_0_5_X_error_init_missing,
+  ZSTD_0_5_X_error_memory_allocation,
+  ZSTD_0_5_X_error_stage_wrong,
+  ZSTD_0_5_X_error_dstSize_tooSmall,
+  ZSTD_0_5_X_error_srcSize_wrong,
+  ZSTD_0_5_X_error_corruption_detected,
+  ZSTD_0_5_X_error_tableLog_tooLarge,
+  ZSTD_0_5_X_error_maxSymbolValue_tooLarge,
+  ZSTD_0_5_X_error_maxSymbolValue_tooSmall,
+  ZSTD_0_5_X_error_dictionary_corrupted,
+  ZSTD_0_5_X_error_maxCode
+} ZSTD_0_5_X_ErrorCode;
 
 /* note : functions provide error codes in reverse negative order,
           so compare with (size_t)(0-enum) */

--- a/fse.c
+++ b/fse.c
@@ -32,7 +32,7 @@
     - Public forum : https://groups.google.com/forum/#!forum/lz4c
 ****************************************************************** */
 
-#ifndef FSE_COMMONDEFS_ONLY
+#ifndef FSE_0_5_X_COMMONDEFS_ONLY
 
 /* **************************************************************
 *  Tuning parameters
@@ -42,24 +42,24 @@
 *  Increasing memory usage improves compression ratio
 *  Reduced memory usage can improve speed, due to cache effect
 *  Recommended max value is 14, for 16KB, which nicely fits into Intel x86 L1 cache */
-#define FSE_MAX_MEMORY_USAGE 14
-#define FSE_DEFAULT_MEMORY_USAGE 13
+#define FSE_0_5_X_MAX_MEMORY_USAGE 14
+#define FSE_0_5_X_DEFAULT_MEMORY_USAGE 13
 
-/*!FSE_MAX_SYMBOL_VALUE :
+/*!FSE_0_5_X_MAX_SYMBOL_VALUE :
 *  Maximum symbol value authorized.
 *  Required for proper stack allocation */
-#define FSE_MAX_SYMBOL_VALUE 255
+#define FSE_0_5_X_MAX_SYMBOL_VALUE 255
 
 
 /* **************************************************************
 *  template functions type & suffix
 ****************************************************************/
-#define FSE_FUNCTION_TYPE BYTE
-#define FSE_FUNCTION_EXTENSION
-#define FSE_DECODE_TYPE FSE_decode_t
+#define FSE_0_5_X_FUNCTION_TYPE BYTE
+#define FSE_0_5_X_FUNCTION_EXTENSION
+#define FSE_0_5_X_DECODE_TYPE FSE_0_5_X_decode_t
 
 
-#endif   /* !FSE_COMMONDEFS_ONLY */
+#endif   /* !FSE_0_5_X_COMMONDEFS_ONLY */
 
 /* **************************************************************
 *  Compiler specifics
@@ -92,29 +92,29 @@
 /* ***************************************************************
 *  Constants
 *****************************************************************/
-#define FSE_MAX_TABLELOG  (FSE_MAX_MEMORY_USAGE-2)
-#define FSE_MAX_TABLESIZE (1U<<FSE_MAX_TABLELOG)
-#define FSE_MAXTABLESIZE_MASK (FSE_MAX_TABLESIZE-1)
-#define FSE_DEFAULT_TABLELOG (FSE_DEFAULT_MEMORY_USAGE-2)
-#define FSE_MIN_TABLELOG 5
+#define FSE_0_5_X_MAX_TABLELOG  (FSE_0_5_X_MAX_MEMORY_USAGE-2)
+#define FSE_0_5_X_MAX_TABLESIZE (1U<<FSE_0_5_X_MAX_TABLELOG)
+#define FSE_0_5_X_MAXTABLESIZE_MASK (FSE_0_5_X_MAX_TABLESIZE-1)
+#define FSE_0_5_X_DEFAULT_TABLELOG (FSE_0_5_X_DEFAULT_MEMORY_USAGE-2)
+#define FSE_0_5_X_MIN_TABLELOG 5
 
-#define FSE_TABLELOG_ABSOLUTE_MAX 15
-#if FSE_MAX_TABLELOG > FSE_TABLELOG_ABSOLUTE_MAX
-#error "FSE_MAX_TABLELOG > FSE_TABLELOG_ABSOLUTE_MAX is not supported"
+#define FSE_0_5_X_TABLELOG_ABSOLUTE_MAX 15
+#if FSE_0_5_X_MAX_TABLELOG > FSE_0_5_X_TABLELOG_ABSOLUTE_MAX
+#error "FSE_0_5_X_MAX_TABLELOG > FSE_0_5_X_TABLELOG_ABSOLUTE_MAX is not supported"
 #endif
 
 
 /* **************************************************************
 *  Error Management
 ****************************************************************/
-#define FSE_STATIC_ASSERT(c) { enum { FSE_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
+#define FSE_0_5_X_STATIC_ASSERT(c) { enum { FSE_0_5_X_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
 
 
 /* **************************************************************
 *  Complex types
 ****************************************************************/
-typedef U32 CTable_max_t[FSE_CTABLE_SIZE_U32(FSE_MAX_TABLELOG, FSE_MAX_SYMBOL_VALUE)];
-typedef U32 DTable_max_t[FSE_DTABLE_SIZE_U32(FSE_MAX_TABLELOG)];
+typedef U32 CTable_max_t[FSE_0_5_X_CTABLE_SIZE_U32(FSE_0_5_X_MAX_TABLELOG, FSE_0_5_X_MAX_SYMBOL_VALUE)];
+typedef U32 DTable_max_t[FSE_0_5_X_DTABLE_SIZE_U32(FSE_0_5_X_MAX_TABLELOG)];
 
 
 /* **************************************************************
@@ -127,34 +127,34 @@ typedef U32 DTable_max_t[FSE_DTABLE_SIZE_U32(FSE_MAX_TABLELOG)];
 */
 
 /* safety checks */
-#ifndef FSE_FUNCTION_EXTENSION
-#  error "FSE_FUNCTION_EXTENSION must be defined"
+#ifndef FSE_0_5_X_FUNCTION_EXTENSION
+#  error "FSE_0_5_X_FUNCTION_EXTENSION must be defined"
 #endif
-#ifndef FSE_FUNCTION_TYPE
-#  error "FSE_FUNCTION_TYPE must be defined"
+#ifndef FSE_0_5_X_FUNCTION_TYPE
+#  error "FSE_0_5_X_FUNCTION_TYPE must be defined"
 #endif
 
 /* Function names */
-#define FSE_CAT(X,Y) X##Y
-#define FSE_FUNCTION_NAME(X,Y) FSE_CAT(X,Y)
-#define FSE_TYPE_NAME(X,Y) FSE_CAT(X,Y)
+#define FSE_0_5_X_CAT(X,Y) X##Y
+#define FSE_0_5_X_FUNCTION_NAME(X,Y) FSE_0_5_X_CAT(X,Y)
+#define FSE_0_5_X_TYPE_NAME(X,Y) FSE_0_5_X_CAT(X,Y)
 
 
 /* Function templates */
-static U32 FSE_tableStep(U32 tableSize) { return (tableSize>>1) + (tableSize>>3) + 3; }
+static U32 FSE_0_5_X_tableStep(U32 tableSize) { return (tableSize>>1) + (tableSize>>3) + 3; }
 
-size_t FSE_buildCTable(FSE_CTable* ct, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog)
+size_t FSE_0_5_X_buildCTable(FSE_0_5_X_CTable* ct, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog)
 {
     const unsigned tableSize = 1 << tableLog;
     const unsigned tableMask = tableSize - 1;
     void* const ptr = ct;
     U16* const tableU16 = ( (U16*) ptr) + 2;
     void* const FSCT = ((U32*)ptr) + 1 /* header */ + (tableLog ? tableSize>>1 : 1) ;
-    FSE_symbolCompressionTransform* const symbolTT = (FSE_symbolCompressionTransform*) (FSCT);
-    const unsigned step = FSE_tableStep(tableSize);
-    unsigned cumul[FSE_MAX_SYMBOL_VALUE+2];
+    FSE_0_5_X_symbolCompressionTransform* const symbolTT = (FSE_0_5_X_symbolCompressionTransform*) (FSCT);
+    const unsigned step = FSE_0_5_X_tableStep(tableSize);
+    unsigned cumul[FSE_0_5_X_MAX_SYMBOL_VALUE+2];
     U32 position = 0;
-    FSE_FUNCTION_TYPE tableSymbol[FSE_MAX_TABLESIZE]; /* memset() is not necessary, even if static analyzer complain about it */
+    FSE_0_5_X_FUNCTION_TYPE tableSymbol[FSE_0_5_X_MAX_TABLESIZE]; /* memset() is not necessary, even if static analyzer complain about it */
     U32 highThreshold = tableSize-1;
     unsigned symbol;
     unsigned i;
@@ -171,7 +171,7 @@ size_t FSE_buildCTable(FSE_CTable* ct, const short* normalizedCounter, unsigned 
     for (i=1; i<=maxSymbolValue+1; i++) {
         if (normalizedCounter[i-1]==-1) {  /* Low proba symbol */
             cumul[i] = cumul[i-1] + 1;
-            tableSymbol[highThreshold--] = (FSE_FUNCTION_TYPE)(i-1);
+            tableSymbol[highThreshold--] = (FSE_0_5_X_FUNCTION_TYPE)(i-1);
         } else {
             cumul[i] = cumul[i-1] + normalizedCounter[i-1];
     }   }
@@ -181,7 +181,7 @@ size_t FSE_buildCTable(FSE_CTable* ct, const short* normalizedCounter, unsigned 
     for (symbol=0; symbol<=maxSymbolValue; symbol++) {
         int nbOccurences;
         for (nbOccurences=0; nbOccurences<normalizedCounter[symbol]; nbOccurences++) {
-            tableSymbol[position] = (FSE_FUNCTION_TYPE)symbol;
+            tableSymbol[position] = (FSE_0_5_X_FUNCTION_TYPE)symbol;
             position = (position + step) & tableMask;
             while (position > highThreshold) position = (position + step) & tableMask;   /* Low proba area */
     }   }
@@ -190,7 +190,7 @@ size_t FSE_buildCTable(FSE_CTable* ct, const short* normalizedCounter, unsigned 
 
     /* Build table */
     for (i=0; i<tableSize; i++) {
-        FSE_FUNCTION_TYPE s = tableSymbol[i];   /* note : static analyzer may not understand tableSymbol is properly initialized */
+        FSE_0_5_X_FUNCTION_TYPE s = tableSymbol[i];   /* note : static analyzer may not understand tableSymbol is properly initialized */
         tableU16[cumul[s]++] = (U16) (tableSize+i);   /* TableU16 : sorted by symbol order; gives next state value */
     }
 
@@ -222,26 +222,26 @@ size_t FSE_buildCTable(FSE_CTable* ct, const short* normalizedCounter, unsigned 
 }
 
 
-FSE_DTable* FSE_createDTable (unsigned tableLog)
+FSE_0_5_X_DTable* FSE_0_5_X_createDTable (unsigned tableLog)
 {
-    if (tableLog > FSE_TABLELOG_ABSOLUTE_MAX) tableLog = FSE_TABLELOG_ABSOLUTE_MAX;
-    return (FSE_DTable*)malloc( FSE_DTABLE_SIZE_U32(tableLog) * sizeof (U32) );
+    if (tableLog > FSE_0_5_X_TABLELOG_ABSOLUTE_MAX) tableLog = FSE_0_5_X_TABLELOG_ABSOLUTE_MAX;
+    return (FSE_0_5_X_DTable*)malloc( FSE_0_5_X_DTABLE_SIZE_U32(tableLog) * sizeof (U32) );
 }
 
-void FSE_freeDTable (FSE_DTable* dt)
+void FSE_0_5_X_freeDTable (FSE_0_5_X_DTable* dt)
 {
     free(dt);
 }
 
-size_t FSE_buildDTable(FSE_DTable* dt, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog)
+size_t FSE_0_5_X_buildDTable(FSE_0_5_X_DTable* dt, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog)
 {
-    FSE_DTableHeader DTableH;
+    FSE_0_5_X_DTableHeader DTableH;
     void* const tdPtr = dt+1;   /* because dt is unsigned, 32-bits aligned on 32-bits */
-    FSE_DECODE_TYPE* const tableDecode = (FSE_DECODE_TYPE*) (tdPtr);
+    FSE_0_5_X_DECODE_TYPE* const tableDecode = (FSE_0_5_X_DECODE_TYPE*) (tdPtr);
     const U32 tableSize = 1 << tableLog;
     const U32 tableMask = tableSize-1;
-    const U32 step = FSE_tableStep(tableSize);
-    U16 symbolNext[FSE_MAX_SYMBOL_VALUE+1];
+    const U32 step = FSE_0_5_X_tableStep(tableSize);
+    U16 symbolNext[FSE_0_5_X_MAX_SYMBOL_VALUE+1];
     U32 position = 0;
     U32 highThreshold = tableSize-1;
     const S16 largeLimit= (S16)(1 << (tableLog-1));
@@ -249,14 +249,14 @@ size_t FSE_buildDTable(FSE_DTable* dt, const short* normalizedCounter, unsigned 
     U32 s;
 
     /* Sanity Checks */
-    if (maxSymbolValue > FSE_MAX_SYMBOL_VALUE) return ERROR(maxSymbolValue_tooLarge);
-    if (tableLog > FSE_MAX_TABLELOG) return ERROR(tableLog_tooLarge);
+    if (maxSymbolValue > FSE_0_5_X_MAX_SYMBOL_VALUE) return ERROR(maxSymbolValue_tooLarge);
+    if (tableLog > FSE_0_5_X_MAX_TABLELOG) return ERROR(tableLog_tooLarge);
 
     /* Init, lay down lowprob symbols */
     DTableH.tableLog = (U16)tableLog;
     for (s=0; s<=maxSymbolValue; s++) {
         if (normalizedCounter[s]==-1) {
-            tableDecode[highThreshold--].symbol = (FSE_FUNCTION_TYPE)s;
+            tableDecode[highThreshold--].symbol = (FSE_0_5_X_FUNCTION_TYPE)s;
             symbolNext[s] = 1;
         } else {
             if (normalizedCounter[s] >= largeLimit) noLarge=0;
@@ -267,7 +267,7 @@ size_t FSE_buildDTable(FSE_DTable* dt, const short* normalizedCounter, unsigned 
     for (s=0; s<=maxSymbolValue; s++) {
         int i;
         for (i=0; i<normalizedCounter[s]; i++) {
-            tableDecode[position].symbol = (FSE_FUNCTION_TYPE)s;
+            tableDecode[position].symbol = (FSE_0_5_X_FUNCTION_TYPE)s;
             position = (position + step) & tableMask;
             while (position > highThreshold) position = (position + step) & tableMask;   /* lowprob area */
     }   }
@@ -278,7 +278,7 @@ size_t FSE_buildDTable(FSE_DTable* dt, const short* normalizedCounter, unsigned 
     {
         U32 i;
         for (i=0; i<tableSize; i++) {
-            FSE_FUNCTION_TYPE symbol = (FSE_FUNCTION_TYPE)(tableDecode[i].symbol);
+            FSE_0_5_X_FUNCTION_TYPE symbol = (FSE_0_5_X_FUNCTION_TYPE)(tableDecode[i].symbol);
             U16 nextState = symbolNext[symbol]++;
             tableDecode[i].nbBits = (BYTE) (tableLog - BIT_highbit32 ((U32)nextState) );
             tableDecode[i].newState = (U16) ( (nextState << tableDecode[i].nbBits) - tableSize);
@@ -290,27 +290,27 @@ size_t FSE_buildDTable(FSE_DTable* dt, const short* normalizedCounter, unsigned 
 }
 
 
-#ifndef FSE_COMMONDEFS_ONLY
+#ifndef FSE_0_5_X_COMMONDEFS_ONLY
 /*-****************************************
 *  FSE helper functions
 ******************************************/
-unsigned FSE_isError(size_t code) { return ERR_isError(code); }
+unsigned FSE_0_5_X_isError(size_t code) { return ERR_isError(code); }
 
-const char* FSE_getErrorName(size_t code) { return ERR_getErrorName(code); }
+const char* FSE_0_5_X_getErrorName(size_t code) { return ERR_getErrorName(code); }
 
 
 /*-**************************************************************
 *  FSE NCount encoding-decoding
 ****************************************************************/
-size_t FSE_NCountWriteBound(unsigned maxSymbolValue, unsigned tableLog)
+size_t FSE_0_5_X_NCountWriteBound(unsigned maxSymbolValue, unsigned tableLog)
 {
     size_t maxHeaderSize = (((maxSymbolValue+1) * tableLog) >> 3) + 3;
-    return maxSymbolValue ? maxHeaderSize : FSE_NCOUNTBOUND;  /* maxSymbolValue==0 ? use default */
+    return maxSymbolValue ? maxHeaderSize : FSE_0_5_X_NCOUNTBOUND;  /* maxSymbolValue==0 ? use default */
 }
 
-static short FSE_abs(short a) { return a<0 ? -a : a; }
+static short FSE_0_5_X_abs(short a) { return a<0 ? -a : a; }
 
-static size_t FSE_writeNCount_generic (void* header, size_t headerBufferSize,
+static size_t FSE_0_5_X_writeNCount_generic (void* header, size_t headerBufferSize,
                                        const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog,
                                        unsigned writeIsSafe)
 {
@@ -329,7 +329,7 @@ static size_t FSE_writeNCount_generic (void* header, size_t headerBufferSize,
     bitStream = 0;
     bitCount  = 0;
     /* Table Size */
-    bitStream += (tableLog-FSE_MIN_TABLELOG) << bitCount;
+    bitStream += (tableLog-FSE_0_5_X_MIN_TABLELOG) << bitCount;
     bitCount  += 4;
 
     /* Init */
@@ -368,7 +368,7 @@ static size_t FSE_writeNCount_generic (void* header, size_t headerBufferSize,
         {
             short count = normalizedCounter[charnum++];
             const short max = (short)((2*threshold-1)-remaining);
-            remaining -= FSE_abs(count);
+            remaining -= FSE_0_5_X_abs(count);
             if (remaining<1) return ERROR(GENERIC);
             count++;   /* +1 for extra accuracy */
             if (count>=threshold) count += max;   /* [0..max[ [max..threshold[ (...) [threshold+max 2*threshold[ */
@@ -399,19 +399,19 @@ static size_t FSE_writeNCount_generic (void* header, size_t headerBufferSize,
 }
 
 
-size_t FSE_writeNCount (void* buffer, size_t bufferSize, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog)
+size_t FSE_0_5_X_writeNCount (void* buffer, size_t bufferSize, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog)
 {
-    if (tableLog > FSE_MAX_TABLELOG) return ERROR(GENERIC);   /* Unsupported */
-    if (tableLog < FSE_MIN_TABLELOG) return ERROR(GENERIC);   /* Unsupported */
+    if (tableLog > FSE_0_5_X_MAX_TABLELOG) return ERROR(GENERIC);   /* Unsupported */
+    if (tableLog < FSE_0_5_X_MIN_TABLELOG) return ERROR(GENERIC);   /* Unsupported */
 
-    if (bufferSize < FSE_NCountWriteBound(maxSymbolValue, tableLog))
-        return FSE_writeNCount_generic(buffer, bufferSize, normalizedCounter, maxSymbolValue, tableLog, 0);
+    if (bufferSize < FSE_0_5_X_NCountWriteBound(maxSymbolValue, tableLog))
+        return FSE_0_5_X_writeNCount_generic(buffer, bufferSize, normalizedCounter, maxSymbolValue, tableLog, 0);
 
-    return FSE_writeNCount_generic(buffer, bufferSize, normalizedCounter, maxSymbolValue, tableLog, 1);
+    return FSE_0_5_X_writeNCount_generic(buffer, bufferSize, normalizedCounter, maxSymbolValue, tableLog, 1);
 }
 
 
-size_t FSE_readNCount (short* normalizedCounter, unsigned* maxSVPtr, unsigned* tableLogPtr,
+size_t FSE_0_5_X_readNCount (short* normalizedCounter, unsigned* maxSVPtr, unsigned* tableLogPtr,
                  const void* headerBuffer, size_t hbSize)
 {
     const BYTE* const istart = (const BYTE*) headerBuffer;
@@ -427,8 +427,8 @@ size_t FSE_readNCount (short* normalizedCounter, unsigned* maxSVPtr, unsigned* t
 
     if (hbSize < 4) return ERROR(srcSize_wrong);
     bitStream = MEM_readLE32(ip);
-    nbBits = (bitStream & 0xF) + FSE_MIN_TABLELOG;   /* extract tableLog */
-    if (nbBits > FSE_TABLELOG_ABSOLUTE_MAX) return ERROR(tableLog_tooLarge);
+    nbBits = (bitStream & 0xF) + FSE_0_5_X_MIN_TABLELOG;   /* extract tableLog */
+    if (nbBits > FSE_0_5_X_TABLELOG_ABSOLUTE_MAX) return ERROR(tableLog_tooLarge);
     bitStream >>= 4;
     bitCount = 4;
     *tableLogPtr = nbBits;
@@ -479,7 +479,7 @@ size_t FSE_readNCount (short* normalizedCounter, unsigned* maxSVPtr, unsigned* t
             }
 
             count--;   /* extra accuracy */
-            remaining -= FSE_abs(count);
+            remaining -= FSE_0_5_X_abs(count);
             normalizedCounter[charnum++] = count;
             previous0 = !count;
             while (remaining < threshold) {
@@ -508,14 +508,14 @@ size_t FSE_readNCount (short* normalizedCounter, unsigned* maxSVPtr, unsigned* t
 /*-**************************************************************
 *  Counting histogram
 ****************************************************************/
-/*! FSE_count_simple
+/*! FSE_0_5_X_count_simple
     This function just counts byte values within @src,
     and store the histogram into @count.
     This function is unsafe : it doesn't check that all values within @src can fit into @count.
     For this reason, prefer using a table @count with 256 elements.
     @return : highest count for a single element
 */
-static size_t FSE_count_simple(unsigned* count, unsigned* maxSymbolValuePtr,
+static size_t FSE_0_5_X_count_simple(unsigned* count, unsigned* maxSymbolValuePtr,
                                const void* src, size_t srcSize)
 {
     const BYTE* ip = (const BYTE*)src;
@@ -538,7 +538,7 @@ static size_t FSE_count_simple(unsigned* count, unsigned* maxSymbolValuePtr,
 }
 
 
-static size_t FSE_count_parallel(unsigned* count, unsigned* maxSymbolValuePtr,
+static size_t FSE_0_5_X_count_parallel(unsigned* count, unsigned* maxSymbolValuePtr,
                                 const void* source, size_t sourceSize,
                                 unsigned checkMax)
 {
@@ -608,20 +608,20 @@ static size_t FSE_count_parallel(unsigned* count, unsigned* maxSymbolValuePtr,
 }
 
 /* fast variant (unsafe : won't check if src contains values beyond count[] limit) */
-size_t FSE_countFast(unsigned* count, unsigned* maxSymbolValuePtr,
+size_t FSE_0_5_X_countFast(unsigned* count, unsigned* maxSymbolValuePtr,
                      const void* source, size_t sourceSize)
 {
-    if (sourceSize < 1500) return FSE_count_simple(count, maxSymbolValuePtr, source, sourceSize);
-    return FSE_count_parallel(count, maxSymbolValuePtr, source, sourceSize, 0);
+    if (sourceSize < 1500) return FSE_0_5_X_count_simple(count, maxSymbolValuePtr, source, sourceSize);
+    return FSE_0_5_X_count_parallel(count, maxSymbolValuePtr, source, sourceSize, 0);
 }
 
-size_t FSE_count(unsigned* count, unsigned* maxSymbolValuePtr,
+size_t FSE_0_5_X_count(unsigned* count, unsigned* maxSymbolValuePtr,
                  const void* source, size_t sourceSize)
 {
     if (*maxSymbolValuePtr <255)
-        return FSE_count_parallel(count, maxSymbolValuePtr, source, sourceSize, 1);
+        return FSE_0_5_X_count_parallel(count, maxSymbolValuePtr, source, sourceSize, 1);
     *maxSymbolValuePtr = 255;
-    return FSE_countFast(count, maxSymbolValuePtr, source, sourceSize);
+    return FSE_0_5_X_countFast(count, maxSymbolValuePtr, source, sourceSize);
 }
 
 
@@ -629,38 +629,38 @@ size_t FSE_count(unsigned* count, unsigned* maxSymbolValuePtr,
 *  FSE Compression Code
 ****************************************************************/
 /*!
-FSE_CTable is a variable size structure which contains :
+FSE_0_5_X_CTable is a variable size structure which contains :
     U16 tableLog;
     U16 maxSymbolValue;
     U16 nextStateNumber[1 << tableLog];                         // This size is variable
-    FSE_symbolCompressionTransform symbolTT[maxSymbolValue+1];  // This size is variable
+    FSE_0_5_X_symbolCompressionTransform symbolTT[maxSymbolValue+1];  // This size is variable
 Allocation is manual, since C standard does not support variable-size structures.
 */
 
-size_t FSE_sizeof_CTable (unsigned maxSymbolValue, unsigned tableLog)
+size_t FSE_0_5_X_sizeof_CTable (unsigned maxSymbolValue, unsigned tableLog)
 {
     size_t size;
-    FSE_STATIC_ASSERT((size_t)FSE_CTABLE_SIZE_U32(FSE_MAX_TABLELOG, FSE_MAX_SYMBOL_VALUE)*4 >= sizeof(CTable_max_t));   /* A compilation error here means FSE_CTABLE_SIZE_U32 is not large enough */
-    if (tableLog > FSE_MAX_TABLELOG) return ERROR(GENERIC);
-    size = FSE_CTABLE_SIZE_U32 (tableLog, maxSymbolValue) * sizeof(U32);
+    FSE_0_5_X_STATIC_ASSERT((size_t)FSE_0_5_X_CTABLE_SIZE_U32(FSE_0_5_X_MAX_TABLELOG, FSE_0_5_X_MAX_SYMBOL_VALUE)*4 >= sizeof(CTable_max_t));   /* A compilation error here means FSE_0_5_X_CTABLE_SIZE_U32 is not large enough */
+    if (tableLog > FSE_0_5_X_MAX_TABLELOG) return ERROR(GENERIC);
+    size = FSE_0_5_X_CTABLE_SIZE_U32 (tableLog, maxSymbolValue) * sizeof(U32);
     return size;
 }
 
-FSE_CTable* FSE_createCTable (unsigned maxSymbolValue, unsigned tableLog)
+FSE_0_5_X_CTable* FSE_0_5_X_createCTable (unsigned maxSymbolValue, unsigned tableLog)
 {
     size_t size;
-    if (tableLog > FSE_TABLELOG_ABSOLUTE_MAX) tableLog = FSE_TABLELOG_ABSOLUTE_MAX;
-    size = FSE_CTABLE_SIZE_U32 (tableLog, maxSymbolValue) * sizeof(U32);
-    return (FSE_CTable*)malloc(size);
+    if (tableLog > FSE_0_5_X_TABLELOG_ABSOLUTE_MAX) tableLog = FSE_0_5_X_TABLELOG_ABSOLUTE_MAX;
+    size = FSE_0_5_X_CTABLE_SIZE_U32 (tableLog, maxSymbolValue) * sizeof(U32);
+    return (FSE_0_5_X_CTable*)malloc(size);
 }
 
-void  FSE_freeCTable (FSE_CTable* ct)
+void  FSE_0_5_X_freeCTable (FSE_0_5_X_CTable* ct)
 {
     free(ct);
 }
 
 /* provides the minimum logSize to safely represent a distribution */
-static unsigned FSE_minTableLog(size_t srcSize, unsigned maxSymbolValue)
+static unsigned FSE_0_5_X_minTableLog(size_t srcSize, unsigned maxSymbolValue)
 {
 	U32 minBitsSrc = BIT_highbit32((U32)(srcSize - 1)) + 1;
 	U32 minBitsSymbols = BIT_highbit32(maxSymbolValue) + 2;
@@ -668,16 +668,16 @@ static unsigned FSE_minTableLog(size_t srcSize, unsigned maxSymbolValue)
 	return minBits;
 }
 
-unsigned FSE_optimalTableLog(unsigned maxTableLog, size_t srcSize, unsigned maxSymbolValue)
+unsigned FSE_0_5_X_optimalTableLog(unsigned maxTableLog, size_t srcSize, unsigned maxSymbolValue)
 {
 	U32 maxBitsSrc = BIT_highbit32((U32)(srcSize - 1)) - 2;
     U32 tableLog = maxTableLog;
-	U32 minBits = FSE_minTableLog(srcSize, maxSymbolValue);
-    if (tableLog==0) tableLog = FSE_DEFAULT_TABLELOG;
+	U32 minBits = FSE_0_5_X_minTableLog(srcSize, maxSymbolValue);
+    if (tableLog==0) tableLog = FSE_0_5_X_DEFAULT_TABLELOG;
 	if (maxBitsSrc < tableLog) tableLog = maxBitsSrc;   /* Accuracy can be reduced */
 	if (minBits > tableLog) tableLog = minBits;   /* Need a minimum to safely represent all symbol values */
-    if (tableLog < FSE_MIN_TABLELOG) tableLog = FSE_MIN_TABLELOG;
-    if (tableLog > FSE_MAX_TABLELOG) tableLog = FSE_MAX_TABLELOG;
+    if (tableLog < FSE_0_5_X_MIN_TABLELOG) tableLog = FSE_0_5_X_MIN_TABLELOG;
+    if (tableLog > FSE_0_5_X_MAX_TABLELOG) tableLog = FSE_0_5_X_MAX_TABLELOG;
     return tableLog;
 }
 
@@ -685,7 +685,7 @@ unsigned FSE_optimalTableLog(unsigned maxTableLog, size_t srcSize, unsigned maxS
 /* Secondary normalization method.
    To be used when primary method fails. */
 
-static size_t FSE_normalizeM2(short* norm, U32 tableLog, const unsigned* count, size_t total, U32 maxSymbolValue)
+static size_t FSE_0_5_X_normalizeM2(short* norm, U32 tableLog, const unsigned* count, size_t total, U32 maxSymbolValue)
 {
     U32 s;
     U32 distributed = 0;
@@ -761,15 +761,15 @@ static size_t FSE_normalizeM2(short* norm, U32 tableLog, const unsigned* count, 
 }
 
 
-size_t FSE_normalizeCount (short* normalizedCounter, unsigned tableLog,
+size_t FSE_0_5_X_normalizeCount (short* normalizedCounter, unsigned tableLog,
                            const unsigned* count, size_t total,
                            unsigned maxSymbolValue)
 {
     /* Sanity checks */
-    if (tableLog==0) tableLog = FSE_DEFAULT_TABLELOG;
-    if (tableLog < FSE_MIN_TABLELOG) return ERROR(GENERIC);   /* Unsupported size */
-    if (tableLog > FSE_MAX_TABLELOG) return ERROR(tableLog_tooLarge);   /* Unsupported size */
-    if (tableLog < FSE_minTableLog(total, maxSymbolValue)) return ERROR(GENERIC);   /* Too small tableLog, compression potentially impossible */
+    if (tableLog==0) tableLog = FSE_0_5_X_DEFAULT_TABLELOG;
+    if (tableLog < FSE_0_5_X_MIN_TABLELOG) return ERROR(GENERIC);   /* Unsupported size */
+    if (tableLog > FSE_0_5_X_MAX_TABLELOG) return ERROR(tableLog_tooLarge);   /* Unsupported size */
+    if (tableLog < FSE_0_5_X_minTableLog(total, maxSymbolValue)) return ERROR(GENERIC);   /* Too small tableLog, compression potentially impossible */
 
     {
         U32 const rtbTable[] = {     0, 473195, 504333, 520860, 550000, 700000, 750000, 830000 };
@@ -800,8 +800,8 @@ size_t FSE_normalizeCount (short* normalizedCounter, unsigned tableLog,
         }   }
         if (-stillToDistribute >= (normalizedCounter[largest] >> 1)) {
             /* corner case, need another normalization method */
-            size_t errorCode = FSE_normalizeM2(normalizedCounter, tableLog, count, total, maxSymbolValue);
-            if (FSE_isError(errorCode)) return errorCode;
+            size_t errorCode = FSE_0_5_X_normalizeM2(normalizedCounter, tableLog, count, total, maxSymbolValue);
+            if (FSE_0_5_X_isError(errorCode)) return errorCode;
         }
         else normalizedCounter[largest] += (short)stillToDistribute;
     }
@@ -824,8 +824,8 @@ size_t FSE_normalizeCount (short* normalizedCounter, unsigned tableLog,
 }
 
 
-/* fake FSE_CTable, for raw (uncompressed) input */
-size_t FSE_buildCTable_raw (FSE_CTable* ct, unsigned nbBits)
+/* fake FSE_0_5_X_CTable, for raw (uncompressed) input */
+size_t FSE_0_5_X_buildCTable_raw (FSE_0_5_X_CTable* ct, unsigned nbBits)
 {
     const unsigned tableSize = 1 << nbBits;
     const unsigned tableMask = tableSize - 1;
@@ -833,7 +833,7 @@ size_t FSE_buildCTable_raw (FSE_CTable* ct, unsigned nbBits)
     void* const ptr = ct;
     U16* const tableU16 = ( (U16*) ptr) + 2;
     void* const FSCT = ((U32*)ptr) + 1 /* header */ + (tableSize>>1);   /* assumption : tableLog >= 1 */
-    FSE_symbolCompressionTransform* const symbolTT = (FSE_symbolCompressionTransform*) (FSCT);
+    FSE_0_5_X_symbolCompressionTransform* const symbolTT = (FSE_0_5_X_symbolCompressionTransform*) (FSCT);
     unsigned s;
 
     /* Sanity checks */
@@ -859,13 +859,13 @@ size_t FSE_buildCTable_raw (FSE_CTable* ct, unsigned nbBits)
     return 0;
 }
 
-/* fake FSE_CTable, for rle (100% always same symbol) input */
-size_t FSE_buildCTable_rle (FSE_CTable* ct, BYTE symbolValue)
+/* fake FSE_0_5_X_CTable, for rle (100% always same symbol) input */
+size_t FSE_0_5_X_buildCTable_rle (FSE_0_5_X_CTable* ct, BYTE symbolValue)
 {
     void* ptr = ct;
     U16* tableU16 = ( (U16*) ptr) + 2;
     void* FSCTptr = (U32*)ptr + 2;
-    FSE_symbolCompressionTransform* symbolTT = (FSE_symbolCompressionTransform*) FSCTptr;
+    FSE_0_5_X_symbolCompressionTransform* symbolTT = (FSE_0_5_X_symbolCompressionTransform*) FSCTptr;
 
     /* header */
     tableU16[-2] = (U16) 0;
@@ -883,9 +883,9 @@ size_t FSE_buildCTable_rle (FSE_CTable* ct, BYTE symbolValue)
 }
 
 
-static size_t FSE_compress_usingCTable_generic (void* dst, size_t dstSize,
+static size_t FSE_0_5_X_compress_usingCTable_generic (void* dst, size_t dstSize,
                            const void* src, size_t srcSize,
-                           const FSE_CTable* ct, const unsigned fast)
+                           const FSE_0_5_X_CTable* ct, const unsigned fast)
 {
     const BYTE* const istart = (const BYTE*) src;
     const BYTE* ip;
@@ -893,71 +893,71 @@ static size_t FSE_compress_usingCTable_generic (void* dst, size_t dstSize,
 
     size_t errorCode;
     BIT_CStream_t bitC;
-    FSE_CState_t CState1, CState2;
+    FSE_0_5_X_CState_t CState1, CState2;
 
 
     /* init */
     errorCode = BIT_initCStream(&bitC, dst, dstSize);
-    if (FSE_isError(errorCode)) return 0;
-    FSE_initCState(&CState1, ct);
+    if (FSE_0_5_X_isError(errorCode)) return 0;
+    FSE_0_5_X_initCState(&CState1, ct);
     CState2 = CState1;
 
     ip=iend;
 
-#define FSE_FLUSHBITS(s)  (fast ? BIT_flushBitsFast(s) : BIT_flushBits(s))
+#define FSE_0_5_X_FLUSHBITS(s)  (fast ? BIT_flushBitsFast(s) : BIT_flushBits(s))
 
     /* join to even */
     if (srcSize & 1) {
-        FSE_encodeSymbol(&bitC, &CState1, *--ip);
-        FSE_FLUSHBITS(&bitC);
+        FSE_0_5_X_encodeSymbol(&bitC, &CState1, *--ip);
+        FSE_0_5_X_FLUSHBITS(&bitC);
     }
 
     /* join to mod 4 */
-    if ((sizeof(bitC.bitContainer)*8 > FSE_MAX_TABLELOG*4+7 ) && (srcSize & 2)) {  /* test bit 2 */
-        FSE_encodeSymbol(&bitC, &CState2, *--ip);
-        FSE_encodeSymbol(&bitC, &CState1, *--ip);
-        FSE_FLUSHBITS(&bitC);
+    if ((sizeof(bitC.bitContainer)*8 > FSE_0_5_X_MAX_TABLELOG*4+7 ) && (srcSize & 2)) {  /* test bit 2 */
+        FSE_0_5_X_encodeSymbol(&bitC, &CState2, *--ip);
+        FSE_0_5_X_encodeSymbol(&bitC, &CState1, *--ip);
+        FSE_0_5_X_FLUSHBITS(&bitC);
     }
 
     /* 2 or 4 encoding per loop */
     for ( ; ip>istart ; )
     {
-        FSE_encodeSymbol(&bitC, &CState2, *--ip);
+        FSE_0_5_X_encodeSymbol(&bitC, &CState2, *--ip);
 
-        if (sizeof(bitC.bitContainer)*8 < FSE_MAX_TABLELOG*2+7 )   /* this test must be static */
-            FSE_FLUSHBITS(&bitC);
+        if (sizeof(bitC.bitContainer)*8 < FSE_0_5_X_MAX_TABLELOG*2+7 )   /* this test must be static */
+            FSE_0_5_X_FLUSHBITS(&bitC);
 
-        FSE_encodeSymbol(&bitC, &CState1, *--ip);
+        FSE_0_5_X_encodeSymbol(&bitC, &CState1, *--ip);
 
-        if (sizeof(bitC.bitContainer)*8 > FSE_MAX_TABLELOG*4+7 ) {  /* this test must be static */
-            FSE_encodeSymbol(&bitC, &CState2, *--ip);
-            FSE_encodeSymbol(&bitC, &CState1, *--ip);
+        if (sizeof(bitC.bitContainer)*8 > FSE_0_5_X_MAX_TABLELOG*4+7 ) {  /* this test must be static */
+            FSE_0_5_X_encodeSymbol(&bitC, &CState2, *--ip);
+            FSE_0_5_X_encodeSymbol(&bitC, &CState1, *--ip);
         }
 
-        FSE_FLUSHBITS(&bitC);
+        FSE_0_5_X_FLUSHBITS(&bitC);
     }
 
-    FSE_flushCState(&bitC, &CState2);
-    FSE_flushCState(&bitC, &CState1);
+    FSE_0_5_X_flushCState(&bitC, &CState2);
+    FSE_0_5_X_flushCState(&bitC, &CState1);
     return BIT_closeCStream(&bitC);
 }
 
-size_t FSE_compress_usingCTable (void* dst, size_t dstSize,
+size_t FSE_0_5_X_compress_usingCTable (void* dst, size_t dstSize,
                            const void* src, size_t srcSize,
-                           const FSE_CTable* ct)
+                           const FSE_0_5_X_CTable* ct)
 {
-    const unsigned fast = (dstSize >= FSE_BLOCKBOUND(srcSize));
+    const unsigned fast = (dstSize >= FSE_0_5_X_BLOCKBOUND(srcSize));
 
     if (fast)
-        return FSE_compress_usingCTable_generic(dst, dstSize, src, srcSize, ct, 1);
+        return FSE_0_5_X_compress_usingCTable_generic(dst, dstSize, src, srcSize, ct, 1);
     else
-        return FSE_compress_usingCTable_generic(dst, dstSize, src, srcSize, ct, 0);
+        return FSE_0_5_X_compress_usingCTable_generic(dst, dstSize, src, srcSize, ct, 0);
 }
 
 
-size_t FSE_compressBound(size_t size) { return FSE_COMPRESSBOUND(size); }
+size_t FSE_0_5_X_compressBound(size_t size) { return FSE_0_5_X_COMPRESSBOUND(size); }
 
-size_t FSE_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog)
+size_t FSE_0_5_X_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog)
 {
     const BYTE* const istart = (const BYTE*) src;
     const BYTE* ip = istart;
@@ -966,36 +966,36 @@ size_t FSE_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize
     BYTE* op = ostart;
     BYTE* const oend = ostart + dstSize;
 
-    U32   count[FSE_MAX_SYMBOL_VALUE+1];
-    S16   norm[FSE_MAX_SYMBOL_VALUE+1];
+    U32   count[FSE_0_5_X_MAX_SYMBOL_VALUE+1];
+    S16   norm[FSE_0_5_X_MAX_SYMBOL_VALUE+1];
     CTable_max_t ct;
     size_t errorCode;
 
     /* init conditions */
     if (srcSize <= 1) return 0;  /* Uncompressible */
-    if (!maxSymbolValue) maxSymbolValue = FSE_MAX_SYMBOL_VALUE;
-    if (!tableLog) tableLog = FSE_DEFAULT_TABLELOG;
+    if (!maxSymbolValue) maxSymbolValue = FSE_0_5_X_MAX_SYMBOL_VALUE;
+    if (!tableLog) tableLog = FSE_0_5_X_DEFAULT_TABLELOG;
 
     /* Scan input and build symbol stats */
-    errorCode = FSE_count (count, &maxSymbolValue, ip, srcSize);
-    if (FSE_isError(errorCode)) return errorCode;
+    errorCode = FSE_0_5_X_count (count, &maxSymbolValue, ip, srcSize);
+    if (FSE_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode == srcSize) return 1;
     if (errorCode == 1) return 0;   /* each symbol only present once */
     if (errorCode < (srcSize >> 7)) return 0;   /* Heuristic : not compressible enough */
 
-    tableLog = FSE_optimalTableLog(tableLog, srcSize, maxSymbolValue);
-    errorCode = FSE_normalizeCount (norm, tableLog, count, srcSize, maxSymbolValue);
-    if (FSE_isError(errorCode)) return errorCode;
+    tableLog = FSE_0_5_X_optimalTableLog(tableLog, srcSize, maxSymbolValue);
+    errorCode = FSE_0_5_X_normalizeCount (norm, tableLog, count, srcSize, maxSymbolValue);
+    if (FSE_0_5_X_isError(errorCode)) return errorCode;
 
     /* Write table description header */
-    errorCode = FSE_writeNCount (op, oend-op, norm, maxSymbolValue, tableLog);
-    if (FSE_isError(errorCode)) return errorCode;
+    errorCode = FSE_0_5_X_writeNCount (op, oend-op, norm, maxSymbolValue, tableLog);
+    if (FSE_0_5_X_isError(errorCode)) return errorCode;
     op += errorCode;
 
     /* Compress */
-    errorCode = FSE_buildCTable (ct, norm, maxSymbolValue, tableLog);
-    if (FSE_isError(errorCode)) return errorCode;
-    errorCode = FSE_compress_usingCTable(op, oend - op, ip, srcSize, ct);
+    errorCode = FSE_0_5_X_buildCTable (ct, norm, maxSymbolValue, tableLog);
+    if (FSE_0_5_X_isError(errorCode)) return errorCode;
+    errorCode = FSE_0_5_X_compress_usingCTable(op, oend - op, ip, srcSize, ct);
     if (errorCode == 0) return 0;   /* not enough space for compressed data */
     op += errorCode;
 
@@ -1006,21 +1006,21 @@ size_t FSE_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize
     return op-ostart;
 }
 
-size_t FSE_compress (void* dst, size_t dstSize, const void* src, size_t srcSize)
+size_t FSE_0_5_X_compress (void* dst, size_t dstSize, const void* src, size_t srcSize)
 {
-    return FSE_compress2(dst, dstSize, src, (U32)srcSize, FSE_MAX_SYMBOL_VALUE, FSE_DEFAULT_TABLELOG);
+    return FSE_0_5_X_compress2(dst, dstSize, src, (U32)srcSize, FSE_0_5_X_MAX_SYMBOL_VALUE, FSE_0_5_X_DEFAULT_TABLELOG);
 }
 
 
 /*-*******************************************************
 *  Decompression (Byte symbols)
 *********************************************************/
-size_t FSE_buildDTable_rle (FSE_DTable* dt, BYTE symbolValue)
+size_t FSE_0_5_X_buildDTable_rle (FSE_0_5_X_DTable* dt, BYTE symbolValue)
 {
     void* ptr = dt;
-    FSE_DTableHeader* const DTableH = (FSE_DTableHeader*)ptr;
+    FSE_0_5_X_DTableHeader* const DTableH = (FSE_0_5_X_DTableHeader*)ptr;
     void* dPtr = dt + 1;
-    FSE_decode_t* const cell = (FSE_decode_t*)dPtr;
+    FSE_0_5_X_decode_t* const cell = (FSE_0_5_X_decode_t*)dPtr;
 
     DTableH->tableLog = 0;
     DTableH->fastMode = 0;
@@ -1033,12 +1033,12 @@ size_t FSE_buildDTable_rle (FSE_DTable* dt, BYTE symbolValue)
 }
 
 
-size_t FSE_buildDTable_raw (FSE_DTable* dt, unsigned nbBits)
+size_t FSE_0_5_X_buildDTable_raw (FSE_0_5_X_DTable* dt, unsigned nbBits)
 {
     void* ptr = dt;
-    FSE_DTableHeader* const DTableH = (FSE_DTableHeader*)ptr;
+    FSE_0_5_X_DTableHeader* const DTableH = (FSE_0_5_X_DTableHeader*)ptr;
     void* dPtr = dt + 1;
-    FSE_decode_t* const dinfo = (FSE_decode_t*)dPtr;
+    FSE_0_5_X_decode_t* const dinfo = (FSE_0_5_X_decode_t*)dPtr;
     const unsigned tableSize = 1 << nbBits;
     const unsigned tableMask = tableSize - 1;
     const unsigned maxSymbolValue = tableMask;
@@ -1059,10 +1059,10 @@ size_t FSE_buildDTable_raw (FSE_DTable* dt, unsigned nbBits)
     return 0;
 }
 
-FORCE_INLINE size_t FSE_decompress_usingDTable_generic(
+FORCE_INLINE size_t FSE_0_5_X_decompress_usingDTable_generic(
           void* dst, size_t maxDstSize,
     const void* cSrc, size_t cSrcSize,
-    const FSE_DTable* dt, const unsigned fast)
+    const FSE_0_5_X_DTable* dt, const unsigned fast)
 {
     BYTE* const ostart = (BYTE*) dst;
     BYTE* op = ostart;
@@ -1070,55 +1070,55 @@ FORCE_INLINE size_t FSE_decompress_usingDTable_generic(
     BYTE* const olimit = omax-3;
 
     BIT_DStream_t bitD;
-    FSE_DState_t state1;
-    FSE_DState_t state2;
+    FSE_0_5_X_DState_t state1;
+    FSE_0_5_X_DState_t state2;
     size_t errorCode;
 
     /* Init */
     errorCode = BIT_initDStream(&bitD, cSrc, cSrcSize);   /* replaced last arg by maxCompressed Size */
-    if (FSE_isError(errorCode)) return errorCode;
+    if (FSE_0_5_X_isError(errorCode)) return errorCode;
 
-    FSE_initDState(&state1, &bitD, dt);
-    FSE_initDState(&state2, &bitD, dt);
+    FSE_0_5_X_initDState(&state1, &bitD, dt);
+    FSE_0_5_X_initDState(&state2, &bitD, dt);
 
-#define FSE_GETSYMBOL(statePtr) fast ? FSE_decodeSymbolFast(statePtr, &bitD) : FSE_decodeSymbol(statePtr, &bitD)
+#define FSE_0_5_X_GETSYMBOL(statePtr) fast ? FSE_0_5_X_decodeSymbolFast(statePtr, &bitD) : FSE_0_5_X_decodeSymbol(statePtr, &bitD)
 
     /* 4 symbols per loop */
     for ( ; (BIT_reloadDStream(&bitD)==BIT_DStream_unfinished) && (op<olimit) ; op+=4) {
-        op[0] = FSE_GETSYMBOL(&state1);
+        op[0] = FSE_0_5_X_GETSYMBOL(&state1);
 
-        if (FSE_MAX_TABLELOG*2+7 > sizeof(bitD.bitContainer)*8)    /* This test must be static */
+        if (FSE_0_5_X_MAX_TABLELOG*2+7 > sizeof(bitD.bitContainer)*8)    /* This test must be static */
             BIT_reloadDStream(&bitD);
 
-        op[1] = FSE_GETSYMBOL(&state2);
+        op[1] = FSE_0_5_X_GETSYMBOL(&state2);
 
-        if (FSE_MAX_TABLELOG*4+7 > sizeof(bitD.bitContainer)*8)    /* This test must be static */
+        if (FSE_0_5_X_MAX_TABLELOG*4+7 > sizeof(bitD.bitContainer)*8)    /* This test must be static */
             { if (BIT_reloadDStream(&bitD) > BIT_DStream_unfinished) { op+=2; break; } }
 
-        op[2] = FSE_GETSYMBOL(&state1);
+        op[2] = FSE_0_5_X_GETSYMBOL(&state1);
 
-        if (FSE_MAX_TABLELOG*2+7 > sizeof(bitD.bitContainer)*8)    /* This test must be static */
+        if (FSE_0_5_X_MAX_TABLELOG*2+7 > sizeof(bitD.bitContainer)*8)    /* This test must be static */
             BIT_reloadDStream(&bitD);
 
-        op[3] = FSE_GETSYMBOL(&state2);
+        op[3] = FSE_0_5_X_GETSYMBOL(&state2);
     }
 
     /* tail */
-    /* note : BIT_reloadDStream(&bitD) >= FSE_DStream_partiallyFilled; Ends at exactly BIT_DStream_completed */
+    /* note : BIT_reloadDStream(&bitD) >= FSE_0_5_X_DStream_partiallyFilled; Ends at exactly BIT_DStream_completed */
     while (1) {
-        if ( (BIT_reloadDStream(&bitD)>BIT_DStream_completed) || (op==omax) || (BIT_endOfDStream(&bitD) && (fast || FSE_endOfDState(&state1))) )
+        if ( (BIT_reloadDStream(&bitD)>BIT_DStream_completed) || (op==omax) || (BIT_endOfDStream(&bitD) && (fast || FSE_0_5_X_endOfDState(&state1))) )
             break;
 
-        *op++ = FSE_GETSYMBOL(&state1);
+        *op++ = FSE_0_5_X_GETSYMBOL(&state1);
 
-        if ( (BIT_reloadDStream(&bitD)>BIT_DStream_completed) || (op==omax) || (BIT_endOfDStream(&bitD) && (fast || FSE_endOfDState(&state2))) )
+        if ( (BIT_reloadDStream(&bitD)>BIT_DStream_completed) || (op==omax) || (BIT_endOfDStream(&bitD) && (fast || FSE_0_5_X_endOfDState(&state2))) )
             break;
 
-        *op++ = FSE_GETSYMBOL(&state2);
+        *op++ = FSE_0_5_X_GETSYMBOL(&state2);
     }
 
     /* end ? */
-    if (BIT_endOfDStream(&bitD) && FSE_endOfDState(&state1) && FSE_endOfDState(&state2))
+    if (BIT_endOfDStream(&bitD) && FSE_0_5_X_endOfDState(&state1) && FSE_0_5_X_endOfDState(&state2))
         return op-ostart;
 
     if (op==omax) return ERROR(dstSize_tooSmall);   /* dst buffer is full, but cSrc unfinished */
@@ -1127,46 +1127,46 @@ FORCE_INLINE size_t FSE_decompress_usingDTable_generic(
 }
 
 
-size_t FSE_decompress_usingDTable(void* dst, size_t originalSize,
+size_t FSE_0_5_X_decompress_usingDTable(void* dst, size_t originalSize,
                             const void* cSrc, size_t cSrcSize,
-                            const FSE_DTable* dt)
+                            const FSE_0_5_X_DTable* dt)
 {
     const void* ptr = dt;
-    const FSE_DTableHeader* DTableH = (const FSE_DTableHeader*)ptr;
+    const FSE_0_5_X_DTableHeader* DTableH = (const FSE_0_5_X_DTableHeader*)ptr;
     const U32 fastMode = DTableH->fastMode;
 
     /* select fast mode (static) */
-    if (fastMode) return FSE_decompress_usingDTable_generic(dst, originalSize, cSrc, cSrcSize, dt, 1);
-    return FSE_decompress_usingDTable_generic(dst, originalSize, cSrc, cSrcSize, dt, 0);
+    if (fastMode) return FSE_0_5_X_decompress_usingDTable_generic(dst, originalSize, cSrc, cSrcSize, dt, 1);
+    return FSE_0_5_X_decompress_usingDTable_generic(dst, originalSize, cSrc, cSrcSize, dt, 0);
 }
 
 
-size_t FSE_decompress(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize)
+size_t FSE_0_5_X_decompress(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize)
 {
     const BYTE* const istart = (const BYTE*)cSrc;
     const BYTE* ip = istart;
-    short counting[FSE_MAX_SYMBOL_VALUE+1];
+    short counting[FSE_0_5_X_MAX_SYMBOL_VALUE+1];
     DTable_max_t dt;   /* Static analyzer seems unable to understand this table will be properly initialized later */
     unsigned tableLog;
-    unsigned maxSymbolValue = FSE_MAX_SYMBOL_VALUE;
+    unsigned maxSymbolValue = FSE_0_5_X_MAX_SYMBOL_VALUE;
     size_t errorCode;
 
     if (cSrcSize<2) return ERROR(srcSize_wrong);   /* too small input size */
 
     /* normal FSE decoding mode */
-    errorCode = FSE_readNCount (counting, &maxSymbolValue, &tableLog, istart, cSrcSize);
-    if (FSE_isError(errorCode)) return errorCode;
+    errorCode = FSE_0_5_X_readNCount (counting, &maxSymbolValue, &tableLog, istart, cSrcSize);
+    if (FSE_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode >= cSrcSize) return ERROR(srcSize_wrong);   /* too small input size */
     ip += errorCode;
     cSrcSize -= errorCode;
 
-    errorCode = FSE_buildDTable (dt, counting, maxSymbolValue, tableLog);
-    if (FSE_isError(errorCode)) return errorCode;
+    errorCode = FSE_0_5_X_buildDTable (dt, counting, maxSymbolValue, tableLog);
+    if (FSE_0_5_X_isError(errorCode)) return errorCode;
 
     /* always return, even if it is an error code */
-    return FSE_decompress_usingDTable (dst, maxDstSize, ip, cSrcSize, dt);
+    return FSE_0_5_X_decompress_usingDTable (dst, maxDstSize, ip, cSrcSize, dt);
 }
 
 
 
-#endif   /* FSE_COMMONDEFS_ONLY */
+#endif   /* FSE_0_5_X_COMMONDEFS_ONLY */

--- a/fse.h
+++ b/fse.h
@@ -32,8 +32,8 @@
    - Source repository : https://github.com/Cyan4973/FiniteStateEntropy
    - Public forum : https://groups.google.com/forum/#!forum/lz4c
 ****************************************************************** */
-#ifndef FSE_H
-#define FSE_H
+#ifndef FSE_0_5_X_H
+#define FSE_0_5_X_H
 
 #if defined (__cplusplus)
 extern "C" {
@@ -49,26 +49,26 @@ extern "C" {
 /*-****************************************
 *  FSE simple functions
 ******************************************/
-size_t FSE_compress(void* dst, size_t maxDstSize,
+size_t FSE_0_5_X_compress(void* dst, size_t maxDstSize,
               const void* src, size_t srcSize);
-size_t FSE_decompress(void* dst,  size_t maxDstSize,
+size_t FSE_0_5_X_decompress(void* dst,  size_t maxDstSize,
                 const void* cSrc, size_t cSrcSize);
 /*!
-FSE_compress():
+FSE_0_5_X_compress():
     Compress content of buffer 'src', of size 'srcSize', into destination buffer 'dst'.
-    'dst' buffer must be already allocated. Compression runs faster is maxDstSize >= FSE_compressBound(srcSize)
+    'dst' buffer must be already allocated. Compression runs faster is maxDstSize >= FSE_0_5_X_compressBound(srcSize)
     return : size of compressed data (<= maxDstSize)
     Special values : if return == 0, srcData is not compressible => Nothing is stored within dst !!!
                      if return == 1, srcData is a single byte symbol * srcSize times. Use RLE compression instead.
-                     if FSE_isError(return), compression failed (more details using FSE_getErrorName())
+                     if FSE_0_5_X_isError(return), compression failed (more details using FSE_0_5_X_getErrorName())
 
-FSE_decompress():
+FSE_0_5_X_decompress():
     Decompress FSE data from buffer 'cSrc', of size 'cSrcSize',
     into already allocated destination buffer 'dst', of size 'maxDstSize'.
     return : size of regenerated data (<= maxDstSize)
-             or an error code, which can be tested using FSE_isError()
+             or an error code, which can be tested using FSE_0_5_X_isError()
 
-    ** Important ** : FSE_decompress() doesn't decompress non-compressible nor RLE data !!!
+    ** Important ** : FSE_0_5_X_decompress() doesn't decompress non-compressible nor RLE data !!!
     Why ? : making this distinction requires a header.
     Header management is intentionally delegated to the user layer, which can better manage special cases.
 */
@@ -77,40 +77,40 @@ FSE_decompress():
 /* *****************************************
 *  Tool functions
 ******************************************/
-size_t FSE_compressBound(size_t size);       /* maximum compressed size */
+size_t FSE_0_5_X_compressBound(size_t size);       /* maximum compressed size */
 
 /* Error Management */
-unsigned    FSE_isError(size_t code);        /* tells if a return value is an error code */
-const char* FSE_getErrorName(size_t code);   /* provides error code string (useful for debugging) */
+unsigned    FSE_0_5_X_isError(size_t code);        /* tells if a return value is an error code */
+const char* FSE_0_5_X_getErrorName(size_t code);   /* provides error code string (useful for debugging) */
 
 
 /* *****************************************
 *  FSE advanced functions
 ******************************************/
 /*!
-FSE_compress2():
-    Same as FSE_compress(), but allows the selection of 'maxSymbolValue' and 'tableLog'
+FSE_0_5_X_compress2():
+    Same as FSE_0_5_X_compress(), but allows the selection of 'maxSymbolValue' and 'tableLog'
     Both parameters can be defined as '0' to mean : use default value
     return : size of compressed data
     Special values : if return == 0, srcData is not compressible => Nothing is stored within cSrc !!!
                      if return == 1, srcData is a single byte symbol * srcSize times. Use RLE compression.
-                     if FSE_isError(return), it's an error code.
+                     if FSE_0_5_X_isError(return), it's an error code.
 */
-size_t FSE_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog);
+size_t FSE_0_5_X_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog);
 
 
 /* *****************************************
 *  FSE detailed API
 ******************************************/
 /*!
-FSE_compress() does the following:
+FSE_0_5_X_compress() does the following:
 1. count symbol occurrence from source[] into table count[]
 2. normalize counters so that sum(count[]) == Power_of_2 (2^tableLog)
 3. save normalized counters to memory buffer using writeNCount()
 4. build encoding table 'CTable' from normalized counters
 5. encode the data stream using encoding table 'CTable'
 
-FSE_decompress() does the following:
+FSE_0_5_X_decompress() does the following:
 1. read normalized counters with readNCount()
 2. build decoding table 'DTable' from normalized counters
 3. decode the data stream using decoding table 'DTable'
@@ -123,141 +123,141 @@ or to save and provide normalized distribution using external method.
 /* *** COMPRESSION *** */
 
 /*!
-FSE_count():
+FSE_0_5_X_count():
    Provides the precise count of each byte within a table 'count'
    'count' is a table of unsigned int, of minimum size (*maxSymbolValuePtr+1).
    *maxSymbolValuePtr will be updated if detected smaller than initial value.
    @return : the count of the most frequent symbol (which is not identified)
              if return == srcSize, there is only one symbol.
-             Can also return an error code, which can be tested with FSE_isError() */
-size_t FSE_count(unsigned* count, unsigned* maxSymbolValuePtr, const void* src, size_t srcSize);
+             Can also return an error code, which can be tested with FSE_0_5_X_isError() */
+size_t FSE_0_5_X_count(unsigned* count, unsigned* maxSymbolValuePtr, const void* src, size_t srcSize);
 
 /*!
-FSE_optimalTableLog():
+FSE_0_5_X_optimalTableLog():
    dynamically downsize 'tableLog' when conditions are met.
    It saves CPU time, by using smaller tables, while preserving or even improving compression ratio.
    return : recommended tableLog (necessarily <= initial 'tableLog') */
-unsigned FSE_optimalTableLog(unsigned tableLog, size_t srcSize, unsigned maxSymbolValue);
+unsigned FSE_0_5_X_optimalTableLog(unsigned tableLog, size_t srcSize, unsigned maxSymbolValue);
 
 /*!
-FSE_normalizeCount():
+FSE_0_5_X_normalizeCount():
    normalize counters so that sum(count[]) == Power_of_2 (2^tableLog)
    'normalizedCounter' is a table of short, of minimum size (maxSymbolValue+1).
    return : tableLog,
-            or an errorCode, which can be tested using FSE_isError() */
-size_t FSE_normalizeCount(short* normalizedCounter, unsigned tableLog, const unsigned* count, size_t srcSize, unsigned maxSymbolValue);
+            or an errorCode, which can be tested using FSE_0_5_X_isError() */
+size_t FSE_0_5_X_normalizeCount(short* normalizedCounter, unsigned tableLog, const unsigned* count, size_t srcSize, unsigned maxSymbolValue);
 
 /*!
-FSE_NCountWriteBound():
+FSE_0_5_X_NCountWriteBound():
    Provides the maximum possible size of an FSE normalized table, given 'maxSymbolValue' and 'tableLog'
    Typically useful for allocation purpose. */
-size_t FSE_NCountWriteBound(unsigned maxSymbolValue, unsigned tableLog);
+size_t FSE_0_5_X_NCountWriteBound(unsigned maxSymbolValue, unsigned tableLog);
 
 /*!
-FSE_writeNCount():
+FSE_0_5_X_writeNCount():
    Compactly save 'normalizedCounter' into 'buffer'.
    return : size of the compressed table
-            or an errorCode, which can be tested using FSE_isError() */
-size_t FSE_writeNCount (void* buffer, size_t bufferSize, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog);
+            or an errorCode, which can be tested using FSE_0_5_X_isError() */
+size_t FSE_0_5_X_writeNCount (void* buffer, size_t bufferSize, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog);
 
 
 /*!
-Constructor and Destructor of type FSE_CTable
+Constructor and Destructor of type FSE_0_5_X_CTable
     Note that its size depends on 'tableLog' and 'maxSymbolValue' */
-typedef unsigned FSE_CTable;   /* don't allocate that. It's only meant to be more restrictive than void* */
-FSE_CTable* FSE_createCTable (unsigned tableLog, unsigned maxSymbolValue);
-void        FSE_freeCTable (FSE_CTable* ct);
+typedef unsigned FSE_0_5_X_CTable;   /* don't allocate that. It's only meant to be more restrictive than void* */
+FSE_0_5_X_CTable* FSE_0_5_X_createCTable (unsigned tableLog, unsigned maxSymbolValue);
+void        FSE_0_5_X_freeCTable (FSE_0_5_X_CTable* ct);
 
 /*!
-FSE_buildCTable():
-   Builds @ct, which must be already allocated, using FSE_createCTable()
+FSE_0_5_X_buildCTable():
+   Builds @ct, which must be already allocated, using FSE_0_5_X_createCTable()
    return : 0
-            or an errorCode, which can be tested using FSE_isError() */
-size_t FSE_buildCTable(FSE_CTable* ct, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog);
+            or an errorCode, which can be tested using FSE_0_5_X_isError() */
+size_t FSE_0_5_X_buildCTable(FSE_0_5_X_CTable* ct, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog);
 
 /*!
-FSE_compress_usingCTable():
+FSE_0_5_X_compress_usingCTable():
    Compress @src using @ct into @dst which must be already allocated
    return : size of compressed data (<= @dstCapacity)
             or 0 if compressed data could not fit into @dst
-            or an errorCode, which can be tested using FSE_isError() */
-size_t FSE_compress_usingCTable (void* dst, size_t dstCapacity, const void* src, size_t srcSize, const FSE_CTable* ct);
+            or an errorCode, which can be tested using FSE_0_5_X_isError() */
+size_t FSE_0_5_X_compress_usingCTable (void* dst, size_t dstCapacity, const void* src, size_t srcSize, const FSE_0_5_X_CTable* ct);
 
 /*!
 Tutorial :
 ----------
-The first step is to count all symbols. FSE_count() does this job very fast.
+The first step is to count all symbols. FSE_0_5_X_count() does this job very fast.
 Result will be saved into 'count', a table of unsigned int, which must be already allocated, and have 'maxSymbolValuePtr[0]+1' cells.
 'src' is a table of bytes of size 'srcSize'. All values within 'src' MUST be <= maxSymbolValuePtr[0]
 maxSymbolValuePtr[0] will be updated, with its real value (necessarily <= original value)
-FSE_count() will return the number of occurrence of the most frequent symbol.
+FSE_0_5_X_count() will return the number of occurrence of the most frequent symbol.
 This can be used to know if there is a single symbol within 'src', and to quickly evaluate its compressibility.
-If there is an error, the function will return an ErrorCode (which can be tested using FSE_isError()).
+If there is an error, the function will return an ErrorCode (which can be tested using FSE_0_5_X_isError()).
 
 The next step is to normalize the frequencies.
-FSE_normalizeCount() will ensure that sum of frequencies is == 2 ^'tableLog'.
+FSE_0_5_X_normalizeCount() will ensure that sum of frequencies is == 2 ^'tableLog'.
 It also guarantees a minimum of 1 to any Symbol with frequency >= 1.
 You can use 'tableLog'==0 to mean "use default tableLog value".
-If you are unsure of which tableLog value to use, you can ask FSE_optimalTableLog(),
+If you are unsure of which tableLog value to use, you can ask FSE_0_5_X_optimalTableLog(),
 which will provide the optimal valid tableLog given sourceSize, maxSymbolValue, and a user-defined maximum (0 means "default").
 
-The result of FSE_normalizeCount() will be saved into a table,
+The result of FSE_0_5_X_normalizeCount() will be saved into a table,
 called 'normalizedCounter', which is a table of signed short.
 'normalizedCounter' must be already allocated, and have at least 'maxSymbolValue+1' cells.
 The return value is tableLog if everything proceeded as expected.
 It is 0 if there is a single symbol within distribution.
-If there is an error (ex: invalid tableLog value), the function will return an ErrorCode (which can be tested using FSE_isError()).
+If there is an error (ex: invalid tableLog value), the function will return an ErrorCode (which can be tested using FSE_0_5_X_isError()).
 
-'normalizedCounter' can be saved in a compact manner to a memory area using FSE_writeNCount().
+'normalizedCounter' can be saved in a compact manner to a memory area using FSE_0_5_X_writeNCount().
 'buffer' must be already allocated.
-For guaranteed success, buffer size must be at least FSE_headerBound().
+For guaranteed success, buffer size must be at least FSE_0_5_X_headerBound().
 The result of the function is the number of bytes written into 'buffer'.
-If there is an error, the function will return an ErrorCode (which can be tested using FSE_isError(); ex : buffer size too small).
+If there is an error, the function will return an ErrorCode (which can be tested using FSE_0_5_X_isError(); ex : buffer size too small).
 
 'normalizedCounter' can then be used to create the compression table 'CTable'.
-The space required by 'CTable' must be already allocated, using FSE_createCTable().
-You can then use FSE_buildCTable() to fill 'CTable'.
-If there is an error, both functions will return an ErrorCode (which can be tested using FSE_isError()).
+The space required by 'CTable' must be already allocated, using FSE_0_5_X_createCTable().
+You can then use FSE_0_5_X_buildCTable() to fill 'CTable'.
+If there is an error, both functions will return an ErrorCode (which can be tested using FSE_0_5_X_isError()).
 
-'CTable' can then be used to compress 'src', with FSE_compress_usingCTable().
-Similar to FSE_count(), the convention is that 'src' is assumed to be a table of char of size 'srcSize'
+'CTable' can then be used to compress 'src', with FSE_0_5_X_compress_usingCTable().
+Similar to FSE_0_5_X_count(), the convention is that 'src' is assumed to be a table of char of size 'srcSize'
 The function returns the size of compressed data (without header), necessarily <= @dstCapacity.
 If it returns '0', compressed data could not fit into 'dst'.
-If there is an error, the function will return an ErrorCode (which can be tested using FSE_isError()).
+If there is an error, the function will return an ErrorCode (which can be tested using FSE_0_5_X_isError()).
 */
 
 
 /* *** DECOMPRESSION *** */
 
 /*!
-FSE_readNCount():
+FSE_0_5_X_readNCount():
    Read compactly saved 'normalizedCounter' from 'rBuffer'.
    return : size read from 'rBuffer'
-            or an errorCode, which can be tested using FSE_isError()
+            or an errorCode, which can be tested using FSE_0_5_X_isError()
             maxSymbolValuePtr[0] and tableLogPtr[0] will also be updated with their respective values */
-size_t FSE_readNCount (short* normalizedCounter, unsigned* maxSymbolValuePtr, unsigned* tableLogPtr, const void* rBuffer, size_t rBuffSize);
+size_t FSE_0_5_X_readNCount (short* normalizedCounter, unsigned* maxSymbolValuePtr, unsigned* tableLogPtr, const void* rBuffer, size_t rBuffSize);
 
 /*!
-Constructor and Destructor of type FSE_DTable
+Constructor and Destructor of type FSE_0_5_X_DTable
     Note that its size depends on 'tableLog' */
-typedef unsigned FSE_DTable;   /* don't allocate that. It's just a way to be more restrictive than void* */
-FSE_DTable* FSE_createDTable(unsigned tableLog);
-void        FSE_freeDTable(FSE_DTable* dt);
+typedef unsigned FSE_0_5_X_DTable;   /* don't allocate that. It's just a way to be more restrictive than void* */
+FSE_0_5_X_DTable* FSE_0_5_X_createDTable(unsigned tableLog);
+void        FSE_0_5_X_freeDTable(FSE_0_5_X_DTable* dt);
 
 /*!
-FSE_buildDTable():
-   Builds 'dt', which must be already allocated, using FSE_createDTable()
+FSE_0_5_X_buildDTable():
+   Builds 'dt', which must be already allocated, using FSE_0_5_X_createDTable()
    return : 0,
-            or an errorCode, which can be tested using FSE_isError() */
-size_t FSE_buildDTable (FSE_DTable* dt, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog);
+            or an errorCode, which can be tested using FSE_0_5_X_isError() */
+size_t FSE_0_5_X_buildDTable (FSE_0_5_X_DTable* dt, const short* normalizedCounter, unsigned maxSymbolValue, unsigned tableLog);
 
 /*!
-FSE_decompress_usingDTable():
+FSE_0_5_X_decompress_usingDTable():
    Decompress compressed source @cSrc of size @cSrcSize using @dt
    into @dst which must be already allocated.
    return : size of regenerated data (necessarily <= @dstCapacity)
-            or an errorCode, which can be tested using FSE_isError() */
-size_t FSE_decompress_usingDTable(void* dst, size_t dstCapacity, const void* cSrc, size_t cSrcSize, const FSE_DTable* dt);
+            or an errorCode, which can be tested using FSE_0_5_X_isError() */
+size_t FSE_0_5_X_decompress_usingDTable(void* dst, size_t dstCapacity, const void* cSrc, size_t cSrcSize, const FSE_0_5_X_DTable* dt);
 
 /*!
 Tutorial :
@@ -267,24 +267,24 @@ Tutorial :
  If block is a single repeated byte, use memset() instead )
 
 The first step is to obtain the normalized frequencies of symbols.
-This can be performed by FSE_readNCount() if it was saved using FSE_writeNCount().
+This can be performed by FSE_0_5_X_readNCount() if it was saved using FSE_0_5_X_writeNCount().
 'normalizedCounter' must be already allocated, and have at least 'maxSymbolValuePtr[0]+1' cells of signed short.
 In practice, that means it's necessary to know 'maxSymbolValue' beforehand,
 or size the table to handle worst case situations (typically 256).
-FSE_readNCount() will provide 'tableLog' and 'maxSymbolValue'.
-The result of FSE_readNCount() is the number of bytes read from 'rBuffer'.
+FSE_0_5_X_readNCount() will provide 'tableLog' and 'maxSymbolValue'.
+The result of FSE_0_5_X_readNCount() is the number of bytes read from 'rBuffer'.
 Note that 'rBufferSize' must be at least 4 bytes, even if useful information is less than that.
-If there is an error, the function will return an error code, which can be tested using FSE_isError().
+If there is an error, the function will return an error code, which can be tested using FSE_0_5_X_isError().
 
-The next step is to build the decompression tables 'FSE_DTable' from 'normalizedCounter'.
-This is performed by the function FSE_buildDTable().
-The space required by 'FSE_DTable' must be already allocated using FSE_createDTable().
-If there is an error, the function will return an error code, which can be tested using FSE_isError().
+The next step is to build the decompression tables 'FSE_0_5_X_DTable' from 'normalizedCounter'.
+This is performed by the function FSE_0_5_X_buildDTable().
+The space required by 'FSE_0_5_X_DTable' must be already allocated using FSE_0_5_X_createDTable().
+If there is an error, the function will return an error code, which can be tested using FSE_0_5_X_isError().
 
-'FSE_DTable' can then be used to decompress 'cSrc', with FSE_decompress_usingDTable().
+'FSE_0_5_X_DTable' can then be used to decompress 'cSrc', with FSE_0_5_X_decompress_usingDTable().
 'cSrcSize' must be strictly correct, otherwise decompression will fail.
-FSE_decompress_usingDTable() result will tell how many bytes were regenerated (<=maxDstSize).
-If there is an error, the function will return an error code, which can be tested using FSE_isError(). (ex: dst buffer too small)
+FSE_0_5_X_decompress_usingDTable() result will tell how many bytes were regenerated (<=maxDstSize).
+If there is an error, the function will return an error code, which can be tested using FSE_0_5_X_isError(). (ex: dst buffer too small)
 */
 
 
@@ -292,4 +292,4 @@ If there is an error, the function will return an error code, which can be teste
 }
 #endif
 
-#endif  /* FSE_H */
+#endif  /* FSE_0_5_X_H */

--- a/fse_static.h
+++ b/fse_static.h
@@ -32,8 +32,8 @@
    - Source repository : https://github.com/Cyan4973/FiniteStateEntropy
    - Public forum : https://groups.google.com/forum/#!forum/lz4c
 ****************************************************************** */
-#ifndef FSE_STATIC_H
-#define FSE_STATIC_H
+#ifndef FSE_0_5_X_STATIC_H
+#define FSE_0_5_X_STATIC_H
 
 #if defined (__cplusplus)
 extern "C" {
@@ -51,32 +51,32 @@ extern "C" {
 *  Static allocation
 *******************************************/
 /* FSE buffer bounds */
-#define FSE_NCOUNTBOUND 512
-#define FSE_BLOCKBOUND(size) (size + (size>>7))
-#define FSE_COMPRESSBOUND(size) (FSE_NCOUNTBOUND + FSE_BLOCKBOUND(size))   /* Macro version, useful for static allocation */
+#define FSE_0_5_X_NCOUNTBOUND 512
+#define FSE_0_5_X_BLOCKBOUND(size) (size + (size>>7))
+#define FSE_0_5_X_COMPRESSBOUND(size) (FSE_0_5_X_NCOUNTBOUND + FSE_0_5_X_BLOCKBOUND(size))   /* Macro version, useful for static allocation */
 
 /* It is possible to statically allocate FSE CTable/DTable as a table of unsigned using below macros */
-#define FSE_CTABLE_SIZE_U32(maxTableLog, maxSymbolValue)   (1 + (1<<(maxTableLog-1)) + ((maxSymbolValue+1)*2))
-#define FSE_DTABLE_SIZE_U32(maxTableLog)                   (1 + (1<<maxTableLog))
+#define FSE_0_5_X_CTABLE_SIZE_U32(maxTableLog, maxSymbolValue)   (1 + (1<<(maxTableLog-1)) + ((maxSymbolValue+1)*2))
+#define FSE_0_5_X_DTABLE_SIZE_U32(maxTableLog)                   (1 + (1<<maxTableLog))
 
 
 /* *****************************************
 *  FSE advanced API
 *******************************************/
-size_t FSE_countFast(unsigned* count, unsigned* maxSymbolValuePtr, const void* src, size_t srcSize);
-/* same as FSE_count(), but blindly trusts that all byte values within src are <= *maxSymbolValuePtr  */
+size_t FSE_0_5_X_countFast(unsigned* count, unsigned* maxSymbolValuePtr, const void* src, size_t srcSize);
+/* same as FSE_0_5_X_count(), but blindly trusts that all byte values within src are <= *maxSymbolValuePtr  */
 
-size_t FSE_buildCTable_raw (FSE_CTable* ct, unsigned nbBits);
-/* build a fake FSE_CTable, designed to not compress an input, where each symbol uses nbBits */
+size_t FSE_0_5_X_buildCTable_raw (FSE_0_5_X_CTable* ct, unsigned nbBits);
+/* build a fake FSE_0_5_X_CTable, designed to not compress an input, where each symbol uses nbBits */
 
-size_t FSE_buildCTable_rle (FSE_CTable* ct, unsigned char symbolValue);
-/* build a fake FSE_CTable, designed to compress always the same symbolValue */
+size_t FSE_0_5_X_buildCTable_rle (FSE_0_5_X_CTable* ct, unsigned char symbolValue);
+/* build a fake FSE_0_5_X_CTable, designed to compress always the same symbolValue */
 
-size_t FSE_buildDTable_raw (FSE_DTable* dt, unsigned nbBits);
-/* build a fake FSE_DTable, designed to read an uncompressed bitstream where each symbol uses nbBits */
+size_t FSE_0_5_X_buildDTable_raw (FSE_0_5_X_DTable* dt, unsigned nbBits);
+/* build a fake FSE_0_5_X_DTable, designed to read an uncompressed bitstream where each symbol uses nbBits */
 
-size_t FSE_buildDTable_rle (FSE_DTable* dt, unsigned char symbolValue);
-/* build a fake FSE_DTable, designed to always generate the same symbolValue */
+size_t FSE_0_5_X_buildDTable_rle (FSE_0_5_X_DTable* dt, unsigned char symbolValue);
+/* build a fake FSE_0_5_X_DTable, designed to always generate the same symbolValue */
 
 
 /* *****************************************
@@ -95,16 +95,16 @@ typedef struct
     const void* stateTable;
     const void* symbolTT;
     unsigned    stateLog;
-} FSE_CState_t;
+} FSE_0_5_X_CState_t;
 
-static void FSE_initCState(FSE_CState_t* CStatePtr, const FSE_CTable* ct);
+static void FSE_0_5_X_initCState(FSE_0_5_X_CState_t* CStatePtr, const FSE_0_5_X_CTable* ct);
 
-static void FSE_encodeSymbol(BIT_CStream_t* bitC, FSE_CState_t* CStatePtr, unsigned symbol);
+static void FSE_0_5_X_encodeSymbol(BIT_CStream_t* bitC, FSE_0_5_X_CState_t* CStatePtr, unsigned symbol);
 
-static void FSE_flushCState(BIT_CStream_t* bitC, const FSE_CState_t* CStatePtr);
+static void FSE_0_5_X_flushCState(BIT_CStream_t* bitC, const FSE_0_5_X_CState_t* CStatePtr);
 
 /*!
-These functions are inner components of FSE_compress_usingCTable().
+These functions are inner components of FSE_0_5_X_compress_usingCTable().
 They allow the creation of custom streams, mixing multiple tables and bit sources.
 
 A key property to keep in mind is that encoding and decoding are done **in reverse direction**.
@@ -112,20 +112,20 @@ So the first symbol you will encode is the last you will decode, like a LIFO sta
 
 You will need a few variables to track your CStream. They are :
 
-FSE_CTable    ct;         // Provided by FSE_buildCTable()
+FSE_0_5_X_CTable    ct;         // Provided by FSE_0_5_X_buildCTable()
 BIT_CStream_t bitStream;  // bitStream tracking structure
-FSE_CState_t  state;      // State tracking structure (can have several)
+FSE_0_5_X_CState_t  state;      // State tracking structure (can have several)
 
 
 The first thing to do is to init bitStream and state.
     size_t errorCode = BIT_initCStream(&bitStream, dstBuffer, maxDstSize);
-    FSE_initCState(&state, ct);
+    FSE_0_5_X_initCState(&state, ct);
 
-Note that BIT_initCStream() can produce an error code, so its result should be tested, using FSE_isError();
+Note that BIT_initCStream() can produce an error code, so its result should be tested, using FSE_0_5_X_isError();
 You can then encode your input data, byte after byte.
-FSE_encodeSymbol() outputs a maximum of 'tableLog' bits at a time.
+FSE_0_5_X_encodeSymbol() outputs a maximum of 'tableLog' bits at a time.
 Remember decoding will be done in reverse direction.
-    FSE_encodeByte(&bitStream, &state, symbol);
+    FSE_0_5_X_encodeByte(&bitStream, &state, symbol);
 
 At any time, you can also add any bit sequence.
 Note : maximum allowed nbBits is 25, for compatibility with 32-bits decoders
@@ -137,12 +137,12 @@ Writing data to memory is a manual operation, performed by the flushBits functio
     BIT_flushBits(&bitStream);
 
 Your last FSE encoding operation shall be to flush your last state value(s).
-    FSE_flushState(&bitStream, &state);
+    FSE_0_5_X_flushState(&bitStream, &state);
 
 Finally, you must close the bitStream.
 The function returns the size of CStream in bytes.
 If data couldn't fit into dstBuffer, it will return a 0 ( == not compressible)
-If there is an error, it returns an errorCode (which can be tested using FSE_isError()).
+If there is an error, it returns an errorCode (which can be tested using FSE_0_5_X_isError()).
     size_t size = BIT_closeCStream(&bitStream);
 */
 
@@ -154,37 +154,37 @@ typedef struct
 {
     size_t      state;
     const void* table;   /* precise table may vary, depending on U16 */
-} FSE_DState_t;
+} FSE_0_5_X_DState_t;
 
 
-static void     FSE_initDState(FSE_DState_t* DStatePtr, BIT_DStream_t* bitD, const FSE_DTable* dt);
+static void     FSE_0_5_X_initDState(FSE_0_5_X_DState_t* DStatePtr, BIT_DStream_t* bitD, const FSE_0_5_X_DTable* dt);
 
-static unsigned char FSE_decodeSymbol(FSE_DState_t* DStatePtr, BIT_DStream_t* bitD);
+static unsigned char FSE_0_5_X_decodeSymbol(FSE_0_5_X_DState_t* DStatePtr, BIT_DStream_t* bitD);
 
-static unsigned FSE_endOfDState(const FSE_DState_t* DStatePtr);
+static unsigned FSE_0_5_X_endOfDState(const FSE_0_5_X_DState_t* DStatePtr);
 
 /*!
-Let's now decompose FSE_decompress_usingDTable() into its unitary components.
+Let's now decompose FSE_0_5_X_decompress_usingDTable() into its unitary components.
 You will decode FSE-encoded symbols from the bitStream,
 and also any other bitFields you put in, **in reverse order**.
 
 You will need a few variables to track your bitStream. They are :
 
 BIT_DStream_t DStream;    // Stream context
-FSE_DState_t  DState;     // State context. Multiple ones are possible
-FSE_DTable*   DTablePtr;  // Decoding table, provided by FSE_buildDTable()
+FSE_0_5_X_DState_t  DState;     // State context. Multiple ones are possible
+FSE_0_5_X_DTable*   DTablePtr;  // Decoding table, provided by FSE_0_5_X_buildDTable()
 
 The first thing to do is to init the bitStream.
     errorCode = BIT_initDStream(&DStream, srcBuffer, srcSize);
 
 You should then retrieve your initial state(s)
 (in reverse flushing order if you have several ones) :
-    errorCode = FSE_initDState(&DState, &DStream, DTablePtr);
+    errorCode = FSE_0_5_X_initDState(&DState, &DStream, DTablePtr);
 
 You can then decode your data, symbol after symbol.
-For information the maximum number of bits read by FSE_decodeSymbol() is 'tableLog'.
+For information the maximum number of bits read by FSE_0_5_X_decodeSymbol() is 'tableLog'.
 Keep in mind that symbols are decoded in reverse order, like a LIFO stack (last in, first out).
-    unsigned char symbol = FSE_decodeSymbol(&DState, &DStream);
+    unsigned char symbol = FSE_0_5_X_decodeSymbol(&DState, &DStream);
 
 You can retrieve any bitfield you eventually stored into the bitStream (in reverse order)
 Note : maximum allowed nbBits is 25, for 32-bits compatibility
@@ -192,7 +192,7 @@ Note : maximum allowed nbBits is 25, for 32-bits compatibility
 
 All above operations only read from local register (which size depends on size_t).
 Refueling the register from memory is manually performed by the reload method.
-    endSignal = FSE_reloadDStream(&DStream);
+    endSignal = FSE_0_5_X_reloadDStream(&DStream);
 
 BIT_reloadDStream() result tells if there is still some more data to read from DStream.
 BIT_DStream_unfinished : there is still some data left into the DStream.
@@ -209,14 +209,14 @@ When it's done, verify decompression is fully completed, by checking both DStrea
 Checking if DStream has reached its end is performed by :
     BIT_endOfDStream(&DStream);
 Check also the states. There might be some symbols left there, if some high probability ones (>50%) are possible.
-    FSE_endOfDState(&DState);
+    FSE_0_5_X_endOfDState(&DState);
 */
 
 
 /* *****************************************
 *  FSE unsafe API
 *******************************************/
-static unsigned char FSE_decodeSymbolFast(FSE_DState_t* DStatePtr, BIT_DStream_t* bitD);
+static unsigned char FSE_0_5_X_decodeSymbolFast(FSE_0_5_X_DState_t* DStatePtr, BIT_DStream_t* bitD);
 /* faster, but works only if nbBits is always >= 1 (otherwise, result will be corrupted) */
 
 
@@ -226,9 +226,9 @@ static unsigned char FSE_decodeSymbolFast(FSE_DState_t* DStatePtr, BIT_DStream_t
 typedef struct {
     int deltaFindState;
     U32 deltaNbBits;
-} FSE_symbolCompressionTransform; /* total 8 bytes */
+} FSE_0_5_X_symbolCompressionTransform; /* total 8 bytes */
 
-MEM_STATIC void FSE_initCState(FSE_CState_t* statePtr, const FSE_CTable* ct)
+MEM_STATIC void FSE_0_5_X_initCState(FSE_0_5_X_CState_t* statePtr, const FSE_0_5_X_CTable* ct)
 {
     const void* ptr = ct;
     const U16* u16ptr = (const U16*) ptr;
@@ -239,11 +239,11 @@ MEM_STATIC void FSE_initCState(FSE_CState_t* statePtr, const FSE_CTable* ct)
     statePtr->stateLog = tableLog;
 }
 
-MEM_STATIC void FSE_initCState2(FSE_CState_t* statePtr, const FSE_CTable* ct, U32 symbol)
+MEM_STATIC void FSE_0_5_X_initCState2(FSE_0_5_X_CState_t* statePtr, const FSE_0_5_X_CTable* ct, U32 symbol)
 {
-    FSE_initCState(statePtr, ct);
+    FSE_0_5_X_initCState(statePtr, ct);
     {
-        const FSE_symbolCompressionTransform symbolTT = ((const FSE_symbolCompressionTransform*)(statePtr->symbolTT))[symbol];
+        const FSE_0_5_X_symbolCompressionTransform symbolTT = ((const FSE_0_5_X_symbolCompressionTransform*)(statePtr->symbolTT))[symbol];
         const U16* stateTable = (const U16*)(statePtr->stateTable);
         U32 nbBitsOut  = (U32)((symbolTT.deltaNbBits + (1<<15)) >> 16);
         statePtr->value = (nbBitsOut << 16) - symbolTT.deltaNbBits;
@@ -252,16 +252,16 @@ MEM_STATIC void FSE_initCState2(FSE_CState_t* statePtr, const FSE_CTable* ct, U3
     }
 }
 
-MEM_STATIC void FSE_encodeSymbol(BIT_CStream_t* bitC, FSE_CState_t* statePtr, U32 symbol)
+MEM_STATIC void FSE_0_5_X_encodeSymbol(BIT_CStream_t* bitC, FSE_0_5_X_CState_t* statePtr, U32 symbol)
 {
-    const FSE_symbolCompressionTransform symbolTT = ((const FSE_symbolCompressionTransform*)(statePtr->symbolTT))[symbol];
+    const FSE_0_5_X_symbolCompressionTransform symbolTT = ((const FSE_0_5_X_symbolCompressionTransform*)(statePtr->symbolTT))[symbol];
     const U16* const stateTable = (const U16*)(statePtr->stateTable);
     U32 nbBitsOut  = (U32)((statePtr->value + symbolTT.deltaNbBits) >> 16);
     BIT_addBits(bitC, statePtr->value, nbBitsOut);
     statePtr->value = stateTable[ (statePtr->value >> nbBitsOut) + symbolTT.deltaFindState];
 }
 
-MEM_STATIC void FSE_flushCState(BIT_CStream_t* bitC, const FSE_CState_t* statePtr)
+MEM_STATIC void FSE_0_5_X_flushCState(BIT_CStream_t* bitC, const FSE_0_5_X_CState_t* statePtr)
 {
     BIT_addBits(bitC, statePtr->value, statePtr->stateLog);
     BIT_flushBits(bitC);
@@ -272,38 +272,38 @@ MEM_STATIC void FSE_flushCState(BIT_CStream_t* bitC, const FSE_CState_t* statePt
 typedef struct {
     U16 tableLog;
     U16 fastMode;
-} FSE_DTableHeader;   /* sizeof U32 */
+} FSE_0_5_X_DTableHeader;   /* sizeof U32 */
 
 typedef struct
 {
     unsigned short newState;
     unsigned char  symbol;
     unsigned char  nbBits;
-} FSE_decode_t;   /* size == U32 */
+} FSE_0_5_X_decode_t;   /* size == U32 */
 
-MEM_STATIC void FSE_initDState(FSE_DState_t* DStatePtr, BIT_DStream_t* bitD, const FSE_DTable* dt)
+MEM_STATIC void FSE_0_5_X_initDState(FSE_0_5_X_DState_t* DStatePtr, BIT_DStream_t* bitD, const FSE_0_5_X_DTable* dt)
 {
     const void* ptr = dt;
-    const FSE_DTableHeader* const DTableH = (const FSE_DTableHeader*)ptr;
+    const FSE_0_5_X_DTableHeader* const DTableH = (const FSE_0_5_X_DTableHeader*)ptr;
     DStatePtr->state = BIT_readBits(bitD, DTableH->tableLog);
     BIT_reloadDStream(bitD);
     DStatePtr->table = dt + 1;
 }
 
-MEM_STATIC size_t FSE_getStateValue(FSE_DState_t* DStatePtr)
+MEM_STATIC size_t FSE_0_5_X_getStateValue(FSE_0_5_X_DState_t* DStatePtr)
 {
     return DStatePtr->state;
 }
 
-MEM_STATIC BYTE FSE_peakSymbol(FSE_DState_t* DStatePtr)
+MEM_STATIC BYTE FSE_0_5_X_peakSymbol(FSE_0_5_X_DState_t* DStatePtr)
 {
-    const FSE_decode_t DInfo = ((const FSE_decode_t*)(DStatePtr->table))[DStatePtr->state];
+    const FSE_0_5_X_decode_t DInfo = ((const FSE_0_5_X_decode_t*)(DStatePtr->table))[DStatePtr->state];
     return DInfo.symbol;
 }
 
-MEM_STATIC BYTE FSE_decodeSymbol(FSE_DState_t* DStatePtr, BIT_DStream_t* bitD)
+MEM_STATIC BYTE FSE_0_5_X_decodeSymbol(FSE_0_5_X_DState_t* DStatePtr, BIT_DStream_t* bitD)
 {
-    const FSE_decode_t DInfo = ((const FSE_decode_t*)(DStatePtr->table))[DStatePtr->state];
+    const FSE_0_5_X_decode_t DInfo = ((const FSE_0_5_X_decode_t*)(DStatePtr->table))[DStatePtr->state];
     const U32  nbBits = DInfo.nbBits;
     BYTE symbol = DInfo.symbol;
     size_t lowBits = BIT_readBits(bitD, nbBits);
@@ -312,9 +312,9 @@ MEM_STATIC BYTE FSE_decodeSymbol(FSE_DState_t* DStatePtr, BIT_DStream_t* bitD)
     return symbol;
 }
 
-MEM_STATIC BYTE FSE_decodeSymbolFast(FSE_DState_t* DStatePtr, BIT_DStream_t* bitD)
+MEM_STATIC BYTE FSE_0_5_X_decodeSymbolFast(FSE_0_5_X_DState_t* DStatePtr, BIT_DStream_t* bitD)
 {
-    const FSE_decode_t DInfo = ((const FSE_decode_t*)(DStatePtr->table))[DStatePtr->state];
+    const FSE_0_5_X_decode_t DInfo = ((const FSE_0_5_X_decode_t*)(DStatePtr->table))[DStatePtr->state];
     const U32 nbBits = DInfo.nbBits;
     BYTE symbol = DInfo.symbol;
     size_t lowBits = BIT_readBitsFast(bitD, nbBits);
@@ -323,7 +323,7 @@ MEM_STATIC BYTE FSE_decodeSymbolFast(FSE_DState_t* DStatePtr, BIT_DStream_t* bit
     return symbol;
 }
 
-MEM_STATIC unsigned FSE_endOfDState(const FSE_DState_t* DStatePtr)
+MEM_STATIC unsigned FSE_0_5_X_endOfDState(const FSE_0_5_X_DState_t* DStatePtr)
 {
     return DStatePtr->state == 0;
 }
@@ -333,4 +333,4 @@ MEM_STATIC unsigned FSE_endOfDState(const FSE_DState_t* DStatePtr)
 }
 #endif
 
-#endif  /* FSE_STATIC_H */
+#endif  /* FSE_0_5_X_STATIC_H */

--- a/huff0.c
+++ b/huff0.c
@@ -70,30 +70,30 @@
 /* **************************************************************
 *  Constants
 ****************************************************************/
-#define HUF_ABSOLUTEMAX_TABLELOG  16   /* absolute limit of HUF_MAX_TABLELOG. Beyond that value, code does not work */
-#define HUF_MAX_TABLELOG  12           /* max configured tableLog (for static allocation); can be modified up to HUF_ABSOLUTEMAX_TABLELOG */
-#define HUF_DEFAULT_TABLELOG  HUF_MAX_TABLELOG   /* tableLog by default, when not specified */
-#define HUF_MAX_SYMBOL_VALUE 255
-#if (HUF_MAX_TABLELOG > HUF_ABSOLUTEMAX_TABLELOG)
-#  error "HUF_MAX_TABLELOG is too large !"
+#define HUF_0_5_X_ABSOLUTEMAX_TABLELOG  16   /* absolute limit of HUF_0_5_X_MAX_TABLELOG. Beyond that value, code does not work */
+#define HUF_0_5_X_MAX_TABLELOG  12           /* max configured tableLog (for static allocation); can be modified up to HUF_0_5_X_ABSOLUTEMAX_TABLELOG */
+#define HUF_0_5_X_DEFAULT_TABLELOG  HUF_0_5_X_MAX_TABLELOG   /* tableLog by default, when not specified */
+#define HUF_0_5_X_MAX_SYMBOL_VALUE 255
+#if (HUF_0_5_X_MAX_TABLELOG > HUF_0_5_X_ABSOLUTEMAX_TABLELOG)
+#  error "HUF_0_5_X_MAX_TABLELOG is too large !"
 #endif
 
 
 /* **************************************************************
 *  Error Management
 ****************************************************************/
-unsigned HUF_isError(size_t code) { return ERR_isError(code); }
-const char* HUF_getErrorName(size_t code) { return ERR_getErrorName(code); }
-#define HUF_STATIC_ASSERT(c) { enum { HUF_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
+unsigned HUF_0_5_X_isError(size_t code) { return ERR_isError(code); }
+const char* HUF_0_5_X_getErrorName(size_t code) { return ERR_getErrorName(code); }
+#define HUF_0_5_X_STATIC_ASSERT(c) { enum { HUF_0_5_X_static_assert = 1/(int)(!!(c)) }; }   /* use only *after* variable declarations */
 
 
 /* *******************************************************
 *  Huff0 : Huffman block compression
 *********************************************************/
-struct HUF_CElt_s {
+struct HUF_0_5_X_CElt_s {
   U16  val;
   BYTE nbBits;
-};   /* typedef'd to HUF_CElt within huff0_static.h */
+};   /* typedef'd to HUF_0_5_X_CElt within huff0_static.h */
 
 typedef struct nodeElt_s {
     U32 count;
@@ -102,21 +102,21 @@ typedef struct nodeElt_s {
     BYTE nbBits;
 } nodeElt;
 
-/*! HUF_writeCTable() :
+/*! HUF_0_5_X_writeCTable() :
     @dst : destination buffer
     @CTable : huffman tree to save, using huff0 representation
     @return : size of saved CTable */
-size_t HUF_writeCTable (void* dst, size_t maxDstSize,
-                        const HUF_CElt* CTable, U32 maxSymbolValue, U32 huffLog)
+size_t HUF_0_5_X_writeCTable (void* dst, size_t maxDstSize,
+                        const HUF_0_5_X_CElt* CTable, U32 maxSymbolValue, U32 huffLog)
 {
-    BYTE bitsToWeight[HUF_MAX_TABLELOG + 1];
-    BYTE huffWeight[HUF_MAX_SYMBOL_VALUE + 1];
+    BYTE bitsToWeight[HUF_0_5_X_MAX_TABLELOG + 1];
+    BYTE huffWeight[HUF_0_5_X_MAX_SYMBOL_VALUE + 1];
     U32 n;
     BYTE* op = (BYTE*)dst;
     size_t size;
 
      /* check conditions */
-    if (maxSymbolValue > HUF_MAX_SYMBOL_VALUE + 1)
+    if (maxSymbolValue > HUF_0_5_X_MAX_SYMBOL_VALUE + 1)
         return ERROR(GENERIC);
 
     /* convert to weight */
@@ -126,8 +126,8 @@ size_t HUF_writeCTable (void* dst, size_t maxDstSize,
     for (n=0; n<maxSymbolValue; n++)
         huffWeight[n] = bitsToWeight[CTable[n].nbBits];
 
-    size = FSE_compress(op+1, maxDstSize-1, huffWeight, maxSymbolValue);   /* don't need last symbol stat : implied */
-    if (HUF_isError(size)) return size;
+    size = FSE_0_5_X_compress(op+1, maxDstSize-1, huffWeight, maxSymbolValue);   /* don't need last symbol stat : implied */
+    if (HUF_0_5_X_isError(size)) return size;
     if (size >= 128) return ERROR(GENERIC);   /* should never happen, since maxSymbolValue <= 255 */
     if ((size <= 1) || (size >= maxSymbolValue/2)) {
         if (size==1) {  /* RLE */
@@ -171,15 +171,15 @@ size_t HUF_writeCTable (void* dst, size_t maxDstSize,
 }
 
 
-static size_t HUF_readStats(BYTE* huffWeight, size_t hwSize, U32* rankStats,
+static size_t HUF_0_5_X_readStats(BYTE* huffWeight, size_t hwSize, U32* rankStats,
                             U32* nbSymbolsPtr, U32* tableLogPtr,
                             const void* src, size_t srcSize);
 
 
-size_t HUF_readCTable (HUF_CElt* CTable, U32 maxSymbolValue, const void* src, size_t srcSize)
+size_t HUF_0_5_X_readCTable (HUF_0_5_X_CElt* CTable, U32 maxSymbolValue, const void* src, size_t srcSize)
 {
-    BYTE huffWeight[HUF_MAX_SYMBOL_VALUE + 1];
-    U32 rankVal[HUF_ABSOLUTEMAX_TABLELOG + 1];   /* large enough for values from 0 to 16 */
+    BYTE huffWeight[HUF_0_5_X_MAX_SYMBOL_VALUE + 1];
+    U32 rankVal[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1];   /* large enough for values from 0 to 16 */
     U32 tableLog = 0;
     size_t iSize;
     U32 nbSymbols = 0;
@@ -188,11 +188,11 @@ size_t HUF_readCTable (HUF_CElt* CTable, U32 maxSymbolValue, const void* src, si
     //memset(huffWeight, 0, sizeof(huffWeight));   /* is not necessary, even though some analyzer complain ... */
 
     /* get symbol weights */
-    iSize = HUF_readStats(huffWeight, HUF_MAX_SYMBOL_VALUE+1, rankVal, &nbSymbols, &tableLog, src, srcSize);
-    if (HUF_isError(iSize)) return iSize;
+    iSize = HUF_0_5_X_readStats(huffWeight, HUF_0_5_X_MAX_SYMBOL_VALUE+1, rankVal, &nbSymbols, &tableLog, src, srcSize);
+    if (HUF_0_5_X_isError(iSize)) return iSize;
 
     /* check result */
-    if (tableLog > HUF_MAX_TABLELOG) return ERROR(tableLog_tooLarge);
+    if (tableLog > HUF_0_5_X_MAX_TABLELOG) return ERROR(tableLog_tooLarge);
     if (nbSymbols > maxSymbolValue+1) return ERROR(maxSymbolValue_tooSmall);
 
     /* Prepare base value per rank */
@@ -211,14 +211,14 @@ size_t HUF_readCTable (HUF_CElt* CTable, U32 maxSymbolValue, const void* src, si
 
     /* fill val */
     {
-        U16 nbPerRank[HUF_MAX_TABLELOG+1] = {0};
-        U16 valPerRank[HUF_MAX_TABLELOG+1] = {0};
+        U16 nbPerRank[HUF_0_5_X_MAX_TABLELOG+1] = {0};
+        U16 valPerRank[HUF_0_5_X_MAX_TABLELOG+1] = {0};
         for (n=0; n<nbSymbols; n++)
             nbPerRank[CTable[n].nbBits]++;
         {
             /* determine stating value per rank */
             U16 min = 0;
-            for (n=HUF_MAX_TABLELOG; n>0; n--) {
+            for (n=HUF_0_5_X_MAX_TABLELOG; n>0; n--) {
                 valPerRank[n] = min;      /* get starting value within each rank */
                 min += nbPerRank[n];
                 min >>= 1;
@@ -231,7 +231,7 @@ size_t HUF_readCTable (HUF_CElt* CTable, U32 maxSymbolValue, const void* src, si
 }
 
 
-static U32 HUF_setMaxHeight(nodeElt* huffNode, U32 lastNonNull, U32 maxNbBits)
+static U32 HUF_0_5_X_setMaxHeight(nodeElt* huffNode, U32 lastNonNull, U32 maxNbBits)
 {
     int totalCost = 0;
     const U32 largestBits = huffNode[lastNonNull].nbBits;
@@ -257,7 +257,7 @@ static U32 HUF_setMaxHeight(nodeElt* huffNode, U32 lastNonNull, U32 maxNbBits)
         /* repay normalized cost */
         {
             const U32 noSymbol = 0xF0F0F0F0;
-            U32 rankLast[HUF_MAX_TABLELOG+1];
+            U32 rankLast[HUF_0_5_X_MAX_TABLELOG+1];
             U32 currentNbBits = maxNbBits;
             int pos;
 
@@ -282,7 +282,7 @@ static U32 HUF_setMaxHeight(nodeElt* huffNode, U32 lastNonNull, U32 maxNbBits)
                         if (highTotal <= lowTotal) break;
                 }   }
                 /* only triggered when no more rank 1 symbol left => find closest one (note : there is necessarily at least one !) */
-                while ((nBitsToDecrease<=HUF_MAX_TABLELOG) && (rankLast[nBitsToDecrease] == noSymbol))  /* HUF_MAX_TABLELOG test just to please gcc 5+; but it should not be necessary */
+                while ((nBitsToDecrease<=HUF_0_5_X_MAX_TABLELOG) && (rankLast[nBitsToDecrease] == noSymbol))  /* HUF_0_5_X_MAX_TABLELOG test just to please gcc 5+; but it should not be necessary */
                     nBitsToDecrease ++;
                 totalCost -= 1 << (nBitsToDecrease-1);
                 if (rankLast[nBitsToDecrease-1] == noSymbol)
@@ -318,7 +318,7 @@ typedef struct {
     U32 current;
 } rankPos;
 
-static void HUF_sort(nodeElt* huffNode, const U32* count, U32 maxSymbolValue)
+static void HUF_0_5_X_sort(nodeElt* huffNode, const U32* count, U32 maxSymbolValue)
 {
     rankPos rank[32];
     U32 n;
@@ -341,10 +341,10 @@ static void HUF_sort(nodeElt* huffNode, const U32* count, U32 maxSymbolValue)
 }
 
 
-#define STARTNODE (HUF_MAX_SYMBOL_VALUE+1)
-size_t HUF_buildCTable (HUF_CElt* tree, const U32* count, U32 maxSymbolValue, U32 maxNbBits)
+#define STARTNODE (HUF_0_5_X_MAX_SYMBOL_VALUE+1)
+size_t HUF_0_5_X_buildCTable (HUF_0_5_X_CElt* tree, const U32* count, U32 maxSymbolValue, U32 maxNbBits)
 {
-    nodeElt huffNode0[2*HUF_MAX_SYMBOL_VALUE+1 +1];
+    nodeElt huffNode0[2*HUF_0_5_X_MAX_SYMBOL_VALUE+1 +1];
     nodeElt* huffNode = huffNode0 + 1;
     U32 n, nonNullRank;
     int lowS, lowN;
@@ -352,12 +352,12 @@ size_t HUF_buildCTable (HUF_CElt* tree, const U32* count, U32 maxSymbolValue, U3
     U32 nodeRoot;
 
     /* safety checks */
-    if (maxNbBits == 0) maxNbBits = HUF_DEFAULT_TABLELOG;
-    if (maxSymbolValue > HUF_MAX_SYMBOL_VALUE) return ERROR(GENERIC);
+    if (maxNbBits == 0) maxNbBits = HUF_0_5_X_DEFAULT_TABLELOG;
+    if (maxSymbolValue > HUF_0_5_X_MAX_SYMBOL_VALUE) return ERROR(GENERIC);
     memset(huffNode0, 0, sizeof(huffNode0));
 
     /* sort, decreasing order */
-    HUF_sort(huffNode, count, maxSymbolValue);
+    HUF_0_5_X_sort(huffNode, count, maxSymbolValue);
 
     /* init for parents */
     nonNullRank = maxSymbolValue;
@@ -386,13 +386,13 @@ size_t HUF_buildCTable (HUF_CElt* tree, const U32* count, U32 maxSymbolValue, U3
         huffNode[n].nbBits = huffNode[ huffNode[n].parent ].nbBits + 1;
 
     /* enforce maxTableLog */
-    maxNbBits = HUF_setMaxHeight(huffNode, nonNullRank, maxNbBits);
+    maxNbBits = HUF_0_5_X_setMaxHeight(huffNode, nonNullRank, maxNbBits);
 
     /* fill result into tree (val, nbBits) */
     {
-        U16 nbPerRank[HUF_MAX_TABLELOG+1] = {0};
-        U16 valPerRank[HUF_MAX_TABLELOG+1] = {0};
-        if (maxNbBits > HUF_MAX_TABLELOG) return ERROR(GENERIC);   /* check fit into table */
+        U16 nbPerRank[HUF_0_5_X_MAX_TABLELOG+1] = {0};
+        U16 valPerRank[HUF_0_5_X_MAX_TABLELOG+1] = {0};
+        if (maxNbBits > HUF_0_5_X_MAX_TABLELOG) return ERROR(GENERIC);   /* check fit into table */
         for (n=0; n<=nonNullRank; n++)
             nbPerRank[huffNode[n].nbBits]++;
         {
@@ -413,66 +413,66 @@ size_t HUF_buildCTable (HUF_CElt* tree, const U32* count, U32 maxSymbolValue, U3
     return maxNbBits;
 }
 
-static void HUF_encodeSymbol(BIT_CStream_t* bitCPtr, U32 symbol, const HUF_CElt* CTable)
+static void HUF_0_5_X_encodeSymbol(BIT_CStream_t* bitCPtr, U32 symbol, const HUF_0_5_X_CElt* CTable)
 {
     BIT_addBitsFast(bitCPtr, CTable[symbol].val, CTable[symbol].nbBits);
 }
 
-size_t HUF_compressBound(size_t size) { return HUF_COMPRESSBOUND(size); }
+size_t HUF_0_5_X_compressBound(size_t size) { return HUF_0_5_X_COMPRESSBOUND(size); }
 
-#define HUF_FLUSHBITS(s)  (fast ? BIT_flushBitsFast(s) : BIT_flushBits(s))
+#define HUF_0_5_X_FLUSHBITS(s)  (fast ? BIT_flushBitsFast(s) : BIT_flushBits(s))
 
-#define HUF_FLUSHBITS_1(stream) \
-    if (sizeof((stream)->bitContainer)*8 < HUF_MAX_TABLELOG*2+7) HUF_FLUSHBITS(stream)
+#define HUF_0_5_X_FLUSHBITS_1(stream) \
+    if (sizeof((stream)->bitContainer)*8 < HUF_0_5_X_MAX_TABLELOG*2+7) HUF_0_5_X_FLUSHBITS(stream)
 
-#define HUF_FLUSHBITS_2(stream) \
-    if (sizeof((stream)->bitContainer)*8 < HUF_MAX_TABLELOG*4+7) HUF_FLUSHBITS(stream)
+#define HUF_0_5_X_FLUSHBITS_2(stream) \
+    if (sizeof((stream)->bitContainer)*8 < HUF_0_5_X_MAX_TABLELOG*4+7) HUF_0_5_X_FLUSHBITS(stream)
 
-size_t HUF_compress1X_usingCTable(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_CElt* CTable)
+size_t HUF_0_5_X_compress1X_usingCTable(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_0_5_X_CElt* CTable)
 {
     const BYTE* ip = (const BYTE*) src;
     BYTE* const ostart = (BYTE*)dst;
     BYTE* op = ostart;
     BYTE* const oend = ostart + dstSize;
     size_t n;
-    const unsigned fast = (dstSize >= HUF_BLOCKBOUND(srcSize));
+    const unsigned fast = (dstSize >= HUF_0_5_X_BLOCKBOUND(srcSize));
     size_t errorCode;
     BIT_CStream_t bitC;
 
     /* init */
     if (dstSize < 8) return 0;   /* not enough space to compress */
     errorCode = BIT_initCStream(&bitC, op, oend-op);
-    if (HUF_isError(errorCode)) return 0;
+    if (HUF_0_5_X_isError(errorCode)) return 0;
 
     n = srcSize & ~3;  /* join to mod 4 */
     switch (srcSize & 3)
     {
-        case 3 : HUF_encodeSymbol(&bitC, ip[n+ 2], CTable);
-                 HUF_FLUSHBITS_2(&bitC);
-        case 2 : HUF_encodeSymbol(&bitC, ip[n+ 1], CTable);
-                 HUF_FLUSHBITS_1(&bitC);
-        case 1 : HUF_encodeSymbol(&bitC, ip[n+ 0], CTable);
-                 HUF_FLUSHBITS(&bitC);
+        case 3 : HUF_0_5_X_encodeSymbol(&bitC, ip[n+ 2], CTable);
+                 HUF_0_5_X_FLUSHBITS_2(&bitC);
+        case 2 : HUF_0_5_X_encodeSymbol(&bitC, ip[n+ 1], CTable);
+                 HUF_0_5_X_FLUSHBITS_1(&bitC);
+        case 1 : HUF_0_5_X_encodeSymbol(&bitC, ip[n+ 0], CTable);
+                 HUF_0_5_X_FLUSHBITS(&bitC);
         case 0 :
         default: ;
     }
 
     for (; n>0; n-=4) {  /* note : n&3==0 at this stage */
-        HUF_encodeSymbol(&bitC, ip[n- 1], CTable);
-        HUF_FLUSHBITS_1(&bitC);
-        HUF_encodeSymbol(&bitC, ip[n- 2], CTable);
-        HUF_FLUSHBITS_2(&bitC);
-        HUF_encodeSymbol(&bitC, ip[n- 3], CTable);
-        HUF_FLUSHBITS_1(&bitC);
-        HUF_encodeSymbol(&bitC, ip[n- 4], CTable);
-        HUF_FLUSHBITS(&bitC);
+        HUF_0_5_X_encodeSymbol(&bitC, ip[n- 1], CTable);
+        HUF_0_5_X_FLUSHBITS_1(&bitC);
+        HUF_0_5_X_encodeSymbol(&bitC, ip[n- 2], CTable);
+        HUF_0_5_X_FLUSHBITS_2(&bitC);
+        HUF_0_5_X_encodeSymbol(&bitC, ip[n- 3], CTable);
+        HUF_0_5_X_FLUSHBITS_1(&bitC);
+        HUF_0_5_X_encodeSymbol(&bitC, ip[n- 4], CTable);
+        HUF_0_5_X_FLUSHBITS(&bitC);
     }
 
     return BIT_closeCStream(&bitC);
 }
 
 
-size_t HUF_compress4X_usingCTable(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_CElt* CTable)
+size_t HUF_0_5_X_compress4X_usingCTable(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_0_5_X_CElt* CTable)
 {
     size_t segmentSize = (srcSize+3)/4;   /* first 3 segments */
     size_t errorCode;
@@ -486,29 +486,29 @@ size_t HUF_compress4X_usingCTable(void* dst, size_t dstSize, const void* src, si
     if (srcSize < 12) return 0;   /* no saving possible : too small input */
     op += 6;   /* jumpTable */
 
-    errorCode = HUF_compress1X_usingCTable(op, oend-op, ip, segmentSize, CTable);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_compress1X_usingCTable(op, oend-op, ip, segmentSize, CTable);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode==0) return 0;
     MEM_writeLE16(ostart, (U16)errorCode);
 
     ip += segmentSize;
     op += errorCode;
-    errorCode = HUF_compress1X_usingCTable(op, oend-op, ip, segmentSize, CTable);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_compress1X_usingCTable(op, oend-op, ip, segmentSize, CTable);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode==0) return 0;
     MEM_writeLE16(ostart+2, (U16)errorCode);
 
     ip += segmentSize;
     op += errorCode;
-    errorCode = HUF_compress1X_usingCTable(op, oend-op, ip, segmentSize, CTable);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_compress1X_usingCTable(op, oend-op, ip, segmentSize, CTable);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode==0) return 0;
     MEM_writeLE16(ostart+4, (U16)errorCode);
 
     ip += segmentSize;
     op += errorCode;
-    errorCode = HUF_compress1X_usingCTable(op, oend-op, ip, iend-ip, CTable);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_compress1X_usingCTable(op, oend-op, ip, iend-ip, CTable);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode==0) return 0;
 
     op += errorCode;
@@ -516,7 +516,7 @@ size_t HUF_compress4X_usingCTable(void* dst, size_t dstSize, const void* src, si
 }
 
 
-static size_t HUF_compress_internal (
+static size_t HUF_0_5_X_compress_internal (
                 void* dst, size_t dstSize,
                 const void* src, size_t srcSize,
                 unsigned maxSymbolValue, unsigned huffLog,
@@ -526,41 +526,41 @@ static size_t HUF_compress_internal (
     BYTE* op = ostart;
     BYTE* const oend = ostart + dstSize;
 
-    U32 count[HUF_MAX_SYMBOL_VALUE+1];
-    HUF_CElt CTable[HUF_MAX_SYMBOL_VALUE+1];
+    U32 count[HUF_0_5_X_MAX_SYMBOL_VALUE+1];
+    HUF_0_5_X_CElt CTable[HUF_0_5_X_MAX_SYMBOL_VALUE+1];
     size_t errorCode;
 
     /* checks & inits */
     if (srcSize < 1) return 0;  /* Uncompressed - note : 1 means rle, so first byte must be correct */
     if (dstSize < 1) return 0;  /* not compressible within dst budget */
     if (srcSize > 128 * 1024) return ERROR(srcSize_wrong);   /* current block size limit */
-    if (huffLog > HUF_MAX_TABLELOG) return ERROR(tableLog_tooLarge);
-    if (!maxSymbolValue) maxSymbolValue = HUF_MAX_SYMBOL_VALUE;
-    if (!huffLog) huffLog = HUF_DEFAULT_TABLELOG;
+    if (huffLog > HUF_0_5_X_MAX_TABLELOG) return ERROR(tableLog_tooLarge);
+    if (!maxSymbolValue) maxSymbolValue = HUF_0_5_X_MAX_SYMBOL_VALUE;
+    if (!huffLog) huffLog = HUF_0_5_X_DEFAULT_TABLELOG;
 
     /* Scan input and build symbol stats */
-    errorCode = FSE_count (count, &maxSymbolValue, (const BYTE*)src, srcSize);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = FSE_0_5_X_count (count, &maxSymbolValue, (const BYTE*)src, srcSize);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode == srcSize) { *ostart = ((const BYTE*)src)[0]; return 1; }
     if (errorCode <= (srcSize >> 7)+1) return 0;   /* Heuristic : not compressible enough */
 
     /* Build Huffman Tree */
-    errorCode = HUF_buildCTable (CTable, count, maxSymbolValue, huffLog);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_buildCTable (CTable, count, maxSymbolValue, huffLog);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     huffLog = (U32)errorCode;
 
     /* Write table description header */
-    errorCode = HUF_writeCTable (op, dstSize, CTable, maxSymbolValue, huffLog);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_writeCTable (op, dstSize, CTable, maxSymbolValue, huffLog);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode + 12 >= srcSize) return 0;   /* not useful to try compression */
     op += errorCode;
 
     /* Compress */
     if (singleStream)
-        errorCode = HUF_compress1X_usingCTable(op, oend - op, src, srcSize, CTable);   /* single segment */
+        errorCode = HUF_0_5_X_compress1X_usingCTable(op, oend - op, src, srcSize, CTable);   /* single segment */
     else
-        errorCode = HUF_compress4X_usingCTable(op, oend - op, src, srcSize, CTable);
-    if (HUF_isError(errorCode)) return errorCode;
+        errorCode = HUF_0_5_X_compress4X_usingCTable(op, oend - op, src, srcSize, CTable);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode==0) return 0;
     op += errorCode;
 
@@ -572,42 +572,42 @@ static size_t HUF_compress_internal (
 }
 
 
-size_t HUF_compress1X (void* dst, size_t dstSize,
+size_t HUF_0_5_X_compress1X (void* dst, size_t dstSize,
                 const void* src, size_t srcSize,
                 unsigned maxSymbolValue, unsigned huffLog)
 {
-    return HUF_compress_internal(dst, dstSize, src, srcSize, maxSymbolValue, huffLog, 1);
+    return HUF_0_5_X_compress_internal(dst, dstSize, src, srcSize, maxSymbolValue, huffLog, 1);
 }
 
-size_t HUF_compress2 (void* dst, size_t dstSize,
+size_t HUF_0_5_X_compress2 (void* dst, size_t dstSize,
                 const void* src, size_t srcSize,
                 unsigned maxSymbolValue, unsigned huffLog)
 {
-    return HUF_compress_internal(dst, dstSize, src, srcSize, maxSymbolValue, huffLog, 0);
+    return HUF_0_5_X_compress_internal(dst, dstSize, src, srcSize, maxSymbolValue, huffLog, 0);
 }
 
 
-size_t HUF_compress (void* dst, size_t maxDstSize, const void* src, size_t srcSize)
+size_t HUF_0_5_X_compress (void* dst, size_t maxDstSize, const void* src, size_t srcSize)
 {
-    return HUF_compress2(dst, maxDstSize, src, (U32)srcSize, 255, HUF_DEFAULT_TABLELOG);
+    return HUF_0_5_X_compress2(dst, maxDstSize, src, (U32)srcSize, 255, HUF_0_5_X_DEFAULT_TABLELOG);
 }
 
 
 /* *******************************************************
 *  Huff0 : Huffman block decompression
 *********************************************************/
-typedef struct { BYTE byte; BYTE nbBits; } HUF_DEltX2;   /* single-symbol decoding */
+typedef struct { BYTE byte; BYTE nbBits; } HUF_0_5_X_DEltX2;   /* single-symbol decoding */
 
-typedef struct { U16 sequence; BYTE nbBits; BYTE length; } HUF_DEltX4;  /* double-symbols decoding */
+typedef struct { U16 sequence; BYTE nbBits; BYTE length; } HUF_0_5_X_DEltX4;  /* double-symbols decoding */
 
 typedef struct { BYTE symbol; BYTE weight; } sortedSymbol_t;
 
-/*! HUF_readStats
-    Read compact Huffman tree, saved by HUF_writeCTable
+/*! HUF_0_5_X_readStats
+    Read compact Huffman tree, saved by HUF_0_5_X_writeCTable
     @huffWeight : destination buffer
     @return : size read from `src`
 */
-static size_t HUF_readStats(BYTE* huffWeight, size_t hwSize, U32* rankStats,
+static size_t HUF_0_5_X_readStats(BYTE* huffWeight, size_t hwSize, U32* rankStats,
                             U32* nbSymbolsPtr, U32* tableLogPtr,
                             const void* src, size_t srcSize)
 {
@@ -639,22 +639,22 @@ static size_t HUF_readStats(BYTE* huffWeight, size_t hwSize, U32* rankStats,
     }   }   }
     else  {   /* header compressed with FSE (normal case) */
         if (iSize+1 > srcSize) return ERROR(srcSize_wrong);
-        oSize = FSE_decompress(huffWeight, hwSize-1, ip+1, iSize);   /* max (hwSize-1) values decoded, as last one is implied */
-        if (FSE_isError(oSize)) return oSize;
+        oSize = FSE_0_5_X_decompress(huffWeight, hwSize-1, ip+1, iSize);   /* max (hwSize-1) values decoded, as last one is implied */
+        if (FSE_0_5_X_isError(oSize)) return oSize;
     }
 
     /* collect weight stats */
-    memset(rankStats, 0, (HUF_ABSOLUTEMAX_TABLELOG + 1) * sizeof(U32));
+    memset(rankStats, 0, (HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1) * sizeof(U32));
     weightTotal = 0;
     for (n=0; n<oSize; n++) {
-        if (huffWeight[n] >= HUF_ABSOLUTEMAX_TABLELOG) return ERROR(corruption_detected);
+        if (huffWeight[n] >= HUF_0_5_X_ABSOLUTEMAX_TABLELOG) return ERROR(corruption_detected);
         rankStats[huffWeight[n]]++;
         weightTotal += (1 << huffWeight[n]) >> 1;
     }
 
     /* get last non-null symbol weight (implied, total must be 2^n) */
     tableLog = BIT_highbit32(weightTotal) + 1;
-    if (tableLog > HUF_ABSOLUTEMAX_TABLELOG) return ERROR(corruption_detected);
+    if (tableLog > HUF_0_5_X_ABSOLUTEMAX_TABLELOG) return ERROR(corruption_detected);
     {   /* determine last weight */
         U32 total = 1 << tableLog;
         U32 rest = total - weightTotal;
@@ -679,23 +679,23 @@ static size_t HUF_readStats(BYTE* huffWeight, size_t hwSize, U32* rankStats,
 /*  single-symbol decoding   */
 /*-***************************/
 
-size_t HUF_readDTableX2 (U16* DTable, const void* src, size_t srcSize)
+size_t HUF_0_5_X_readDTableX2 (U16* DTable, const void* src, size_t srcSize)
 {
-    BYTE huffWeight[HUF_MAX_SYMBOL_VALUE + 1];
-    U32 rankVal[HUF_ABSOLUTEMAX_TABLELOG + 1];   /* large enough for values from 0 to 16 */
+    BYTE huffWeight[HUF_0_5_X_MAX_SYMBOL_VALUE + 1];
+    U32 rankVal[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1];   /* large enough for values from 0 to 16 */
     U32 tableLog = 0;
     size_t iSize;
     U32 nbSymbols = 0;
     U32 n;
     U32 nextRankStart;
     void* const dtPtr = DTable + 1;
-    HUF_DEltX2* const dt = (HUF_DEltX2*)dtPtr;
+    HUF_0_5_X_DEltX2* const dt = (HUF_0_5_X_DEltX2*)dtPtr;
 
-    HUF_STATIC_ASSERT(sizeof(HUF_DEltX2) == sizeof(U16));   /* if compilation fails here, assertion is false */
+    HUF_0_5_X_STATIC_ASSERT(sizeof(HUF_0_5_X_DEltX2) == sizeof(U16));   /* if compilation fails here, assertion is false */
     //memset(huffWeight, 0, sizeof(huffWeight));   /* is not necessary, even though some analyzer complain ... */
 
-    iSize = HUF_readStats(huffWeight, HUF_MAX_SYMBOL_VALUE + 1, rankVal, &nbSymbols, &tableLog, src, srcSize);
-    if (HUF_isError(iSize)) return iSize;
+    iSize = HUF_0_5_X_readStats(huffWeight, HUF_0_5_X_MAX_SYMBOL_VALUE + 1, rankVal, &nbSymbols, &tableLog, src, srcSize);
+    if (HUF_0_5_X_isError(iSize)) return iSize;
 
     /* check result */
     if (tableLog > DTable[0]) return ERROR(tableLog_tooLarge);   /* DTable is too small */
@@ -714,7 +714,7 @@ size_t HUF_readDTableX2 (U16* DTable, const void* src, size_t srcSize)
         const U32 w = huffWeight[n];
         const U32 length = (1 << w) >> 1;
         U32 i;
-        HUF_DEltX2 D;
+        HUF_0_5_X_DEltX2 D;
         D.byte = (BYTE)n; D.nbBits = (BYTE)(tableLog + 1 - w);
         for (i = rankVal[w]; i < rankVal[w] + length; i++)
             dt[i] = D;
@@ -724,7 +724,7 @@ size_t HUF_readDTableX2 (U16* DTable, const void* src, size_t srcSize)
     return iSize;
 }
 
-static BYTE HUF_decodeSymbolX2(BIT_DStream_t* Dstream, const HUF_DEltX2* dt, const U32 dtLog)
+static BYTE HUF_0_5_X_decodeSymbolX2(BIT_DStream_t* Dstream, const HUF_0_5_X_DEltX2* dt, const U32 dtLog)
 {
         const size_t val = BIT_lookBitsFast(Dstream, dtLog); /* note : dtLog >= 1 */
         const BYTE c = dt[val].byte;
@@ -732,41 +732,41 @@ static BYTE HUF_decodeSymbolX2(BIT_DStream_t* Dstream, const HUF_DEltX2* dt, con
         return c;
 }
 
-#define HUF_DECODE_SYMBOLX2_0(ptr, DStreamPtr) \
-    *ptr++ = HUF_decodeSymbolX2(DStreamPtr, dt, dtLog)
+#define HUF_0_5_X_DECODE_SYMBOLX2_0(ptr, DStreamPtr) \
+    *ptr++ = HUF_0_5_X_decodeSymbolX2(DStreamPtr, dt, dtLog)
 
-#define HUF_DECODE_SYMBOLX2_1(ptr, DStreamPtr) \
-    if (MEM_64bits() || (HUF_MAX_TABLELOG<=12)) \
-        HUF_DECODE_SYMBOLX2_0(ptr, DStreamPtr)
+#define HUF_0_5_X_DECODE_SYMBOLX2_1(ptr, DStreamPtr) \
+    if (MEM_64bits() || (HUF_0_5_X_MAX_TABLELOG<=12)) \
+        HUF_0_5_X_DECODE_SYMBOLX2_0(ptr, DStreamPtr)
 
-#define HUF_DECODE_SYMBOLX2_2(ptr, DStreamPtr) \
+#define HUF_0_5_X_DECODE_SYMBOLX2_2(ptr, DStreamPtr) \
     if (MEM_64bits()) \
-        HUF_DECODE_SYMBOLX2_0(ptr, DStreamPtr)
+        HUF_0_5_X_DECODE_SYMBOLX2_0(ptr, DStreamPtr)
 
-static inline size_t HUF_decodeStreamX2(BYTE* p, BIT_DStream_t* const bitDPtr, BYTE* const pEnd, const HUF_DEltX2* const dt, const U32 dtLog)
+static inline size_t HUF_0_5_X_decodeStreamX2(BYTE* p, BIT_DStream_t* const bitDPtr, BYTE* const pEnd, const HUF_0_5_X_DEltX2* const dt, const U32 dtLog)
 {
     BYTE* const pStart = p;
 
     /* up to 4 symbols at a time */
     while ((BIT_reloadDStream(bitDPtr) == BIT_DStream_unfinished) && (p <= pEnd-4)) {
-        HUF_DECODE_SYMBOLX2_2(p, bitDPtr);
-        HUF_DECODE_SYMBOLX2_1(p, bitDPtr);
-        HUF_DECODE_SYMBOLX2_2(p, bitDPtr);
-        HUF_DECODE_SYMBOLX2_0(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX2_1(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX2_0(p, bitDPtr);
     }
 
     /* closer to the end */
     while ((BIT_reloadDStream(bitDPtr) == BIT_DStream_unfinished) && (p < pEnd))
-        HUF_DECODE_SYMBOLX2_0(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX2_0(p, bitDPtr);
 
     /* no more data to retrieve from bitstream, hence no need to reload */
     while (p < pEnd)
-        HUF_DECODE_SYMBOLX2_0(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX2_0(p, bitDPtr);
 
     return pEnd-pStart;
 }
 
-size_t HUF_decompress1X2_usingDTable(
+size_t HUF_0_5_X_decompress1X2_usingDTable(
           void* dst,  size_t dstSize,
     const void* cSrc, size_t cSrcSize,
     const U16* DTable)
@@ -776,12 +776,12 @@ size_t HUF_decompress1X2_usingDTable(
     size_t errorCode;
     const U32 dtLog = DTable[0];
     const void* dtPtr = DTable;
-    const HUF_DEltX2* const dt = ((const HUF_DEltX2*)dtPtr)+1;
+    const HUF_0_5_X_DEltX2* const dt = ((const HUF_0_5_X_DEltX2*)dtPtr)+1;
     BIT_DStream_t bitD;
     errorCode = BIT_initDStream(&bitD, cSrc, cSrcSize);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
 
-    HUF_decodeStreamX2(op, &bitD, oend, dt, dtLog);
+    HUF_0_5_X_decodeStreamX2(op, &bitD, oend, dt, dtLog);
 
     /* check */
     if (!BIT_endOfDStream(&bitD)) return ERROR(corruption_detected);
@@ -789,23 +789,23 @@ size_t HUF_decompress1X2_usingDTable(
     return dstSize;
 }
 
-size_t HUF_decompress1X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
+size_t HUF_0_5_X_decompress1X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
 {
-    HUF_CREATE_STATIC_DTABLEX2(DTable, HUF_MAX_TABLELOG);
+    HUF_0_5_X_CREATE_STATIC_DTABLEX2(DTable, HUF_0_5_X_MAX_TABLELOG);
     const BYTE* ip = (const BYTE*) cSrc;
     size_t errorCode;
 
-    errorCode = HUF_readDTableX2 (DTable, cSrc, cSrcSize);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_readDTableX2 (DTable, cSrc, cSrcSize);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode >= cSrcSize) return ERROR(srcSize_wrong);
     ip += errorCode;
     cSrcSize -= errorCode;
 
-    return HUF_decompress1X2_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
+    return HUF_0_5_X_decompress1X2_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
 }
 
 
-size_t HUF_decompress4X2_usingDTable(
+size_t HUF_0_5_X_decompress4X2_usingDTable(
           void* dst,  size_t dstSize,
     const void* cSrc, size_t cSrcSize,
     const U16* DTable)
@@ -814,7 +814,7 @@ size_t HUF_decompress4X2_usingDTable(
     BYTE* const ostart = (BYTE*) dst;
     BYTE* const oend = ostart + dstSize;
     const void* const dtPtr = DTable;
-    const HUF_DEltX2* const dt = ((const HUF_DEltX2*)dtPtr) +1;
+    const HUF_0_5_X_DEltX2* const dt = ((const HUF_0_5_X_DEltX2*)dtPtr) +1;
     const U32 dtLog = DTable[0];
     size_t errorCode;
 
@@ -847,33 +847,33 @@ size_t HUF_decompress4X2_usingDTable(
     length4 = cSrcSize - (length1 + length2 + length3 + 6);
     if (length4 > cSrcSize) return ERROR(corruption_detected);   /* overflow */
     errorCode = BIT_initDStream(&bitD1, istart1, length1);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     errorCode = BIT_initDStream(&bitD2, istart2, length2);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     errorCode = BIT_initDStream(&bitD3, istart3, length3);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     errorCode = BIT_initDStream(&bitD4, istart4, length4);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
 
     /* 16-32 symbols per loop (4-8 symbols per stream) */
     endSignal = BIT_reloadDStream(&bitD1) | BIT_reloadDStream(&bitD2) | BIT_reloadDStream(&bitD3) | BIT_reloadDStream(&bitD4);
     for ( ; (endSignal==BIT_DStream_unfinished) && (op4<(oend-7)) ; ) {
-        HUF_DECODE_SYMBOLX2_2(op1, &bitD1);
-        HUF_DECODE_SYMBOLX2_2(op2, &bitD2);
-        HUF_DECODE_SYMBOLX2_2(op3, &bitD3);
-        HUF_DECODE_SYMBOLX2_2(op4, &bitD4);
-        HUF_DECODE_SYMBOLX2_1(op1, &bitD1);
-        HUF_DECODE_SYMBOLX2_1(op2, &bitD2);
-        HUF_DECODE_SYMBOLX2_1(op3, &bitD3);
-        HUF_DECODE_SYMBOLX2_1(op4, &bitD4);
-        HUF_DECODE_SYMBOLX2_2(op1, &bitD1);
-        HUF_DECODE_SYMBOLX2_2(op2, &bitD2);
-        HUF_DECODE_SYMBOLX2_2(op3, &bitD3);
-        HUF_DECODE_SYMBOLX2_2(op4, &bitD4);
-        HUF_DECODE_SYMBOLX2_0(op1, &bitD1);
-        HUF_DECODE_SYMBOLX2_0(op2, &bitD2);
-        HUF_DECODE_SYMBOLX2_0(op3, &bitD3);
-        HUF_DECODE_SYMBOLX2_0(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX2_1(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX2_1(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX2_1(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX2_1(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX2_2(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX2_0(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX2_0(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX2_0(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX2_0(op4, &bitD4);
         endSignal = BIT_reloadDStream(&bitD1) | BIT_reloadDStream(&bitD2) | BIT_reloadDStream(&bitD3) | BIT_reloadDStream(&bitD4);
     }
 
@@ -884,10 +884,10 @@ size_t HUF_decompress4X2_usingDTable(
     /* note : op4 supposed already verified within main loop */
 
     /* finish bitStreams one by one */
-    HUF_decodeStreamX2(op1, &bitD1, opStart2, dt, dtLog);
-    HUF_decodeStreamX2(op2, &bitD2, opStart3, dt, dtLog);
-    HUF_decodeStreamX2(op3, &bitD3, opStart4, dt, dtLog);
-    HUF_decodeStreamX2(op4, &bitD4, oend,     dt, dtLog);
+    HUF_0_5_X_decodeStreamX2(op1, &bitD1, opStart2, dt, dtLog);
+    HUF_0_5_X_decodeStreamX2(op2, &bitD2, opStart3, dt, dtLog);
+    HUF_0_5_X_decodeStreamX2(op3, &bitD3, opStart4, dt, dtLog);
+    HUF_0_5_X_decodeStreamX2(op4, &bitD4, oend,     dt, dtLog);
 
     /* check */
     endSignal = BIT_endOfDStream(&bitD1) & BIT_endOfDStream(&bitD2) & BIT_endOfDStream(&bitD3) & BIT_endOfDStream(&bitD4);
@@ -898,19 +898,19 @@ size_t HUF_decompress4X2_usingDTable(
 }
 
 
-size_t HUF_decompress4X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
+size_t HUF_0_5_X_decompress4X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
 {
-    HUF_CREATE_STATIC_DTABLEX2(DTable, HUF_MAX_TABLELOG);
+    HUF_0_5_X_CREATE_STATIC_DTABLEX2(DTable, HUF_0_5_X_MAX_TABLELOG);
     const BYTE* ip = (const BYTE*) cSrc;
     size_t errorCode;
 
-    errorCode = HUF_readDTableX2 (DTable, cSrc, cSrcSize);
-    if (HUF_isError(errorCode)) return errorCode;
+    errorCode = HUF_0_5_X_readDTableX2 (DTable, cSrc, cSrcSize);
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     if (errorCode >= cSrcSize) return ERROR(srcSize_wrong);
     ip += errorCode;
     cSrcSize -= errorCode;
 
-    return HUF_decompress4X2_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
+    return HUF_0_5_X_decompress4X2_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
 }
 
 
@@ -918,13 +918,13 @@ size_t HUF_decompress4X2 (void* dst, size_t dstSize, const void* cSrc, size_t cS
 /* double-symbols decoding */
 /* *************************/
 
-static void HUF_fillDTableX4Level2(HUF_DEltX4* DTable, U32 sizeLog, const U32 consumed,
+static void HUF_0_5_X_fillDTableX4Level2(HUF_0_5_X_DEltX4* DTable, U32 sizeLog, const U32 consumed,
                            const U32* rankValOrigin, const int minWeight,
                            const sortedSymbol_t* sortedSymbols, const U32 sortedListSize,
                            U32 nbBitsBaseline, U16 baseSeq)
 {
-    HUF_DEltX4 DElt;
-    U32 rankVal[HUF_ABSOLUTEMAX_TABLELOG + 1];
+    HUF_0_5_X_DEltX4 DElt;
+    U32 rankVal[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1];
     U32 s;
 
     /* get pre-calculated rankVal */
@@ -959,14 +959,14 @@ static void HUF_fillDTableX4Level2(HUF_DEltX4* DTable, U32 sizeLog, const U32 co
     }
 }
 
-typedef U32 rankVal_t[HUF_ABSOLUTEMAX_TABLELOG][HUF_ABSOLUTEMAX_TABLELOG + 1];
+typedef U32 rankVal_t[HUF_0_5_X_ABSOLUTEMAX_TABLELOG][HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1];
 
-static void HUF_fillDTableX4(HUF_DEltX4* DTable, const U32 targetLog,
+static void HUF_0_5_X_fillDTableX4(HUF_0_5_X_DEltX4* DTable, const U32 targetLog,
                            const sortedSymbol_t* sortedList, const U32 sortedListSize,
                            const U32* rankStart, rankVal_t rankValOrigin, const U32 maxWeight,
                            const U32 nbBitsBaseline)
 {
-    U32 rankVal[HUF_ABSOLUTEMAX_TABLELOG + 1];
+    U32 rankVal[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1];
     const int scaleLog = nbBitsBaseline - targetLog;   /* note : targetLog >= srcLog, hence scaleLog <= 1 */
     const U32 minBits  = nbBitsBaseline - maxWeight;
     U32 s;
@@ -986,14 +986,14 @@ static void HUF_fillDTableX4(HUF_DEltX4* DTable, const U32 targetLog,
             int minWeight = nbBits + scaleLog;
             if (minWeight < 1) minWeight = 1;
             sortedRank = rankStart[minWeight];
-            HUF_fillDTableX4Level2(DTable+start, targetLog-nbBits, nbBits,
+            HUF_0_5_X_fillDTableX4Level2(DTable+start, targetLog-nbBits, nbBits,
                            rankValOrigin[nbBits], minWeight,
                            sortedList+sortedRank, sortedListSize-sortedRank,
                            nbBitsBaseline, symbol);
         } else {
             U32 i;
             const U32 end = start + length;
-            HUF_DEltX4 DElt;
+            HUF_0_5_X_DEltX4 DElt;
 
             MEM_writeLE16(&(DElt.sequence), symbol);
             DElt.nbBits   = (BYTE)(nbBits);
@@ -1005,26 +1005,26 @@ static void HUF_fillDTableX4(HUF_DEltX4* DTable, const U32 targetLog,
     }
 }
 
-size_t HUF_readDTableX4 (U32* DTable, const void* src, size_t srcSize)
+size_t HUF_0_5_X_readDTableX4 (U32* DTable, const void* src, size_t srcSize)
 {
-    BYTE weightList[HUF_MAX_SYMBOL_VALUE + 1];
-    sortedSymbol_t sortedSymbol[HUF_MAX_SYMBOL_VALUE + 1];
-    U32 rankStats[HUF_ABSOLUTEMAX_TABLELOG + 1] = { 0 };
-    U32 rankStart0[HUF_ABSOLUTEMAX_TABLELOG + 2] = { 0 };
+    BYTE weightList[HUF_0_5_X_MAX_SYMBOL_VALUE + 1];
+    sortedSymbol_t sortedSymbol[HUF_0_5_X_MAX_SYMBOL_VALUE + 1];
+    U32 rankStats[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1] = { 0 };
+    U32 rankStart0[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 2] = { 0 };
     U32* const rankStart = rankStart0+1;
     rankVal_t rankVal;
     U32 tableLog, maxW, sizeOfSort, nbSymbols;
     const U32 memLog = DTable[0];
     size_t iSize;
     void* dtPtr = DTable;
-    HUF_DEltX4* const dt = ((HUF_DEltX4*)dtPtr) + 1;
+    HUF_0_5_X_DEltX4* const dt = ((HUF_0_5_X_DEltX4*)dtPtr) + 1;
 
-    HUF_STATIC_ASSERT(sizeof(HUF_DEltX4) == sizeof(U32));   /* if compilation fails here, assertion is false */
-    if (memLog > HUF_ABSOLUTEMAX_TABLELOG) return ERROR(tableLog_tooLarge);
+    HUF_0_5_X_STATIC_ASSERT(sizeof(HUF_0_5_X_DEltX4) == sizeof(U32));   /* if compilation fails here, assertion is false */
+    if (memLog > HUF_0_5_X_ABSOLUTEMAX_TABLELOG) return ERROR(tableLog_tooLarge);
     //memset(weightList, 0, sizeof(weightList));   /* is not necessary, even though some analyzer complain ... */
 
-    iSize = HUF_readStats(weightList, HUF_MAX_SYMBOL_VALUE + 1, rankStats, &nbSymbols, &tableLog, src, srcSize);
-    if (HUF_isError(iSize)) return iSize;
+    iSize = HUF_0_5_X_readStats(weightList, HUF_0_5_X_MAX_SYMBOL_VALUE + 1, rankStats, &nbSymbols, &tableLog, src, srcSize);
+    if (HUF_0_5_X_isError(iSize)) return iSize;
 
     /* check result */
     if (tableLog > memLog) return ERROR(tableLog_tooLarge);   /* DTable can't fit code depth */
@@ -1074,7 +1074,7 @@ size_t HUF_readDTableX4 (U32* DTable, const void* src, size_t srcSize)
                 rankValPtr[w] = rankVal0[w] >> consumed;
     }   }   }
 
-    HUF_fillDTableX4(dt, memLog,
+    HUF_0_5_X_fillDTableX4(dt, memLog,
                    sortedSymbol, sizeOfSort,
                    rankStart0, rankVal, maxW,
                    tableLog+1);
@@ -1083,7 +1083,7 @@ size_t HUF_readDTableX4 (U32* DTable, const void* src, size_t srcSize)
 }
 
 
-static U32 HUF_decodeSymbolX4(void* op, BIT_DStream_t* DStream, const HUF_DEltX4* dt, const U32 dtLog)
+static U32 HUF_0_5_X_decodeSymbolX4(void* op, BIT_DStream_t* DStream, const HUF_0_5_X_DEltX4* dt, const U32 dtLog)
 {
     const size_t val = BIT_lookBitsFast(DStream, dtLog);   /* note : dtLog >= 1 */
     memcpy(op, dt+val, 2);
@@ -1091,7 +1091,7 @@ static U32 HUF_decodeSymbolX4(void* op, BIT_DStream_t* DStream, const HUF_DEltX4
     return dt[val].length;
 }
 
-static U32 HUF_decodeLastSymbolX4(void* op, BIT_DStream_t* DStream, const HUF_DEltX4* dt, const U32 dtLog)
+static U32 HUF_0_5_X_decodeLastSymbolX4(void* op, BIT_DStream_t* DStream, const HUF_0_5_X_DEltX4* dt, const U32 dtLog)
 {
     const size_t val = BIT_lookBitsFast(DStream, dtLog);   /* note : dtLog >= 1 */
     memcpy(op, dt+val, 1);
@@ -1106,44 +1106,44 @@ static U32 HUF_decodeLastSymbolX4(void* op, BIT_DStream_t* DStream, const HUF_DE
 }
 
 
-#define HUF_DECODE_SYMBOLX4_0(ptr, DStreamPtr) \
-    ptr += HUF_decodeSymbolX4(ptr, DStreamPtr, dt, dtLog)
+#define HUF_0_5_X_DECODE_SYMBOLX4_0(ptr, DStreamPtr) \
+    ptr += HUF_0_5_X_decodeSymbolX4(ptr, DStreamPtr, dt, dtLog)
 
-#define HUF_DECODE_SYMBOLX4_1(ptr, DStreamPtr) \
-    if (MEM_64bits() || (HUF_MAX_TABLELOG<=12)) \
-        ptr += HUF_decodeSymbolX4(ptr, DStreamPtr, dt, dtLog)
+#define HUF_0_5_X_DECODE_SYMBOLX4_1(ptr, DStreamPtr) \
+    if (MEM_64bits() || (HUF_0_5_X_MAX_TABLELOG<=12)) \
+        ptr += HUF_0_5_X_decodeSymbolX4(ptr, DStreamPtr, dt, dtLog)
 
-#define HUF_DECODE_SYMBOLX4_2(ptr, DStreamPtr) \
+#define HUF_0_5_X_DECODE_SYMBOLX4_2(ptr, DStreamPtr) \
     if (MEM_64bits()) \
-        ptr += HUF_decodeSymbolX4(ptr, DStreamPtr, dt, dtLog)
+        ptr += HUF_0_5_X_decodeSymbolX4(ptr, DStreamPtr, dt, dtLog)
 
-static inline size_t HUF_decodeStreamX4(BYTE* p, BIT_DStream_t* bitDPtr, BYTE* const pEnd, const HUF_DEltX4* const dt, const U32 dtLog)
+static inline size_t HUF_0_5_X_decodeStreamX4(BYTE* p, BIT_DStream_t* bitDPtr, BYTE* const pEnd, const HUF_0_5_X_DEltX4* const dt, const U32 dtLog)
 {
     BYTE* const pStart = p;
 
     /* up to 8 symbols at a time */
     while ((BIT_reloadDStream(bitDPtr) == BIT_DStream_unfinished) && (p < pEnd-7)) {
-        HUF_DECODE_SYMBOLX4_2(p, bitDPtr);
-        HUF_DECODE_SYMBOLX4_1(p, bitDPtr);
-        HUF_DECODE_SYMBOLX4_2(p, bitDPtr);
-        HUF_DECODE_SYMBOLX4_0(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX4_2(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX4_1(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX4_2(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX4_0(p, bitDPtr);
     }
 
     /* closer to the end */
     while ((BIT_reloadDStream(bitDPtr) == BIT_DStream_unfinished) && (p <= pEnd-2))
-        HUF_DECODE_SYMBOLX4_0(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX4_0(p, bitDPtr);
 
     while (p <= pEnd-2)
-        HUF_DECODE_SYMBOLX4_0(p, bitDPtr);   /* no need to reload : reached the end of DStream */
+        HUF_0_5_X_DECODE_SYMBOLX4_0(p, bitDPtr);   /* no need to reload : reached the end of DStream */
 
     if (p < pEnd)
-        p += HUF_decodeLastSymbolX4(p, bitDPtr, dt, dtLog);
+        p += HUF_0_5_X_decodeLastSymbolX4(p, bitDPtr, dt, dtLog);
 
     return p-pStart;
 }
 
 
-size_t HUF_decompress1X4_usingDTable(
+size_t HUF_0_5_X_decompress1X4_usingDTable(
           void* dst,  size_t dstSize,
     const void* cSrc, size_t cSrcSize,
     const U32* DTable)
@@ -1154,16 +1154,16 @@ size_t HUF_decompress1X4_usingDTable(
 
     const U32 dtLog = DTable[0];
     const void* const dtPtr = DTable;
-    const HUF_DEltX4* const dt = ((const HUF_DEltX4*)dtPtr) +1;
+    const HUF_0_5_X_DEltX4* const dt = ((const HUF_0_5_X_DEltX4*)dtPtr) +1;
     size_t errorCode;
 
     /* Init */
     BIT_DStream_t bitD;
     errorCode = BIT_initDStream(&bitD, istart, cSrcSize);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
 
     /* finish bitStreams one by one */
-    HUF_decodeStreamX4(ostart, &bitD, oend,     dt, dtLog);
+    HUF_0_5_X_decodeStreamX4(ostart, &bitD, oend,     dt, dtLog);
 
     /* check */
     if (!BIT_endOfDStream(&bitD)) return ERROR(corruption_detected);
@@ -1172,21 +1172,21 @@ size_t HUF_decompress1X4_usingDTable(
     return dstSize;
 }
 
-size_t HUF_decompress1X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
+size_t HUF_0_5_X_decompress1X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
 {
-    HUF_CREATE_STATIC_DTABLEX4(DTable, HUF_MAX_TABLELOG);
+    HUF_0_5_X_CREATE_STATIC_DTABLEX4(DTable, HUF_0_5_X_MAX_TABLELOG);
     const BYTE* ip = (const BYTE*) cSrc;
 
-    size_t hSize = HUF_readDTableX4 (DTable, cSrc, cSrcSize);
-    if (HUF_isError(hSize)) return hSize;
+    size_t hSize = HUF_0_5_X_readDTableX4 (DTable, cSrc, cSrcSize);
+    if (HUF_0_5_X_isError(hSize)) return hSize;
     if (hSize >= cSrcSize) return ERROR(srcSize_wrong);
     ip += hSize;
     cSrcSize -= hSize;
 
-    return HUF_decompress1X4_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
+    return HUF_0_5_X_decompress1X4_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
 }
 
-size_t HUF_decompress4X4_usingDTable(
+size_t HUF_0_5_X_decompress4X4_usingDTable(
           void* dst,  size_t dstSize,
     const void* cSrc, size_t cSrcSize,
     const U32* DTable)
@@ -1198,7 +1198,7 @@ size_t HUF_decompress4X4_usingDTable(
         BYTE* const ostart = (BYTE*) dst;
         BYTE* const oend = ostart + dstSize;
         const void* const dtPtr = DTable;
-        const HUF_DEltX4* const dt = ((const HUF_DEltX4*)dtPtr) +1;
+        const HUF_0_5_X_DEltX4* const dt = ((const HUF_0_5_X_DEltX4*)dtPtr) +1;
         const U32 dtLog = DTable[0];
         size_t errorCode;
 
@@ -1228,33 +1228,33 @@ size_t HUF_decompress4X4_usingDTable(
         length4 = cSrcSize - (length1 + length2 + length3 + 6);
         if (length4 > cSrcSize) return ERROR(corruption_detected);   /* overflow */
         errorCode = BIT_initDStream(&bitD1, istart1, length1);
-        if (HUF_isError(errorCode)) return errorCode;
+        if (HUF_0_5_X_isError(errorCode)) return errorCode;
         errorCode = BIT_initDStream(&bitD2, istart2, length2);
-        if (HUF_isError(errorCode)) return errorCode;
+        if (HUF_0_5_X_isError(errorCode)) return errorCode;
         errorCode = BIT_initDStream(&bitD3, istart3, length3);
-        if (HUF_isError(errorCode)) return errorCode;
+        if (HUF_0_5_X_isError(errorCode)) return errorCode;
         errorCode = BIT_initDStream(&bitD4, istart4, length4);
-        if (HUF_isError(errorCode)) return errorCode;
+        if (HUF_0_5_X_isError(errorCode)) return errorCode;
 
         /* 16-32 symbols per loop (4-8 symbols per stream) */
         endSignal = BIT_reloadDStream(&bitD1) | BIT_reloadDStream(&bitD2) | BIT_reloadDStream(&bitD3) | BIT_reloadDStream(&bitD4);
         for ( ; (endSignal==BIT_DStream_unfinished) && (op4<(oend-7)) ; ) {
-            HUF_DECODE_SYMBOLX4_2(op1, &bitD1);
-            HUF_DECODE_SYMBOLX4_2(op2, &bitD2);
-            HUF_DECODE_SYMBOLX4_2(op3, &bitD3);
-            HUF_DECODE_SYMBOLX4_2(op4, &bitD4);
-            HUF_DECODE_SYMBOLX4_1(op1, &bitD1);
-            HUF_DECODE_SYMBOLX4_1(op2, &bitD2);
-            HUF_DECODE_SYMBOLX4_1(op3, &bitD3);
-            HUF_DECODE_SYMBOLX4_1(op4, &bitD4);
-            HUF_DECODE_SYMBOLX4_2(op1, &bitD1);
-            HUF_DECODE_SYMBOLX4_2(op2, &bitD2);
-            HUF_DECODE_SYMBOLX4_2(op3, &bitD3);
-            HUF_DECODE_SYMBOLX4_2(op4, &bitD4);
-            HUF_DECODE_SYMBOLX4_0(op1, &bitD1);
-            HUF_DECODE_SYMBOLX4_0(op2, &bitD2);
-            HUF_DECODE_SYMBOLX4_0(op3, &bitD3);
-            HUF_DECODE_SYMBOLX4_0(op4, &bitD4);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op1, &bitD1);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op2, &bitD2);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op3, &bitD3);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op4, &bitD4);
+            HUF_0_5_X_DECODE_SYMBOLX4_1(op1, &bitD1);
+            HUF_0_5_X_DECODE_SYMBOLX4_1(op2, &bitD2);
+            HUF_0_5_X_DECODE_SYMBOLX4_1(op3, &bitD3);
+            HUF_0_5_X_DECODE_SYMBOLX4_1(op4, &bitD4);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op1, &bitD1);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op2, &bitD2);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op3, &bitD3);
+            HUF_0_5_X_DECODE_SYMBOLX4_2(op4, &bitD4);
+            HUF_0_5_X_DECODE_SYMBOLX4_0(op1, &bitD1);
+            HUF_0_5_X_DECODE_SYMBOLX4_0(op2, &bitD2);
+            HUF_0_5_X_DECODE_SYMBOLX4_0(op3, &bitD3);
+            HUF_0_5_X_DECODE_SYMBOLX4_0(op4, &bitD4);
 
             endSignal = BIT_reloadDStream(&bitD1) | BIT_reloadDStream(&bitD2) | BIT_reloadDStream(&bitD3) | BIT_reloadDStream(&bitD4);
         }
@@ -1266,10 +1266,10 @@ size_t HUF_decompress4X4_usingDTable(
         /* note : op4 supposed already verified within main loop */
 
         /* finish bitStreams one by one */
-        HUF_decodeStreamX4(op1, &bitD1, opStart2, dt, dtLog);
-        HUF_decodeStreamX4(op2, &bitD2, opStart3, dt, dtLog);
-        HUF_decodeStreamX4(op3, &bitD3, opStart4, dt, dtLog);
-        HUF_decodeStreamX4(op4, &bitD4, oend,     dt, dtLog);
+        HUF_0_5_X_decodeStreamX4(op1, &bitD1, opStart2, dt, dtLog);
+        HUF_0_5_X_decodeStreamX4(op2, &bitD2, opStart3, dt, dtLog);
+        HUF_0_5_X_decodeStreamX4(op3, &bitD3, opStart4, dt, dtLog);
+        HUF_0_5_X_decodeStreamX4(op4, &bitD4, oend,     dt, dtLog);
 
         /* check */
         endSignal = BIT_endOfDStream(&bitD1) & BIT_endOfDStream(&bitD2) & BIT_endOfDStream(&bitD3) & BIT_endOfDStream(&bitD4);
@@ -1281,37 +1281,37 @@ size_t HUF_decompress4X4_usingDTable(
 }
 
 
-size_t HUF_decompress4X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
+size_t HUF_0_5_X_decompress4X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
 {
-    HUF_CREATE_STATIC_DTABLEX4(DTable, HUF_MAX_TABLELOG);
+    HUF_0_5_X_CREATE_STATIC_DTABLEX4(DTable, HUF_0_5_X_MAX_TABLELOG);
     const BYTE* ip = (const BYTE*) cSrc;
 
-    size_t hSize = HUF_readDTableX4 (DTable, cSrc, cSrcSize);
-    if (HUF_isError(hSize)) return hSize;
+    size_t hSize = HUF_0_5_X_readDTableX4 (DTable, cSrc, cSrcSize);
+    if (HUF_0_5_X_isError(hSize)) return hSize;
     if (hSize >= cSrcSize) return ERROR(srcSize_wrong);
     ip += hSize;
     cSrcSize -= hSize;
 
-    return HUF_decompress4X4_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
+    return HUF_0_5_X_decompress4X4_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
 }
 
 
 /* ********************************/
 /* quad-symbol decoding           */
 /* ********************************/
-typedef struct { BYTE nbBits; BYTE nbBytes; } HUF_DDescX6;
-typedef union { BYTE byte[4]; U32 sequence; } HUF_DSeqX6;
+typedef struct { BYTE nbBits; BYTE nbBytes; } HUF_0_5_X_DDescX6;
+typedef union { BYTE byte[4]; U32 sequence; } HUF_0_5_X_DSeqX6;
 
 /* recursive, up to level 3; may benefit from <template>-like strategy to nest each level inline */
-static void HUF_fillDTableX6LevelN(HUF_DDescX6* DDescription, HUF_DSeqX6* DSequence, int sizeLog,
+static void HUF_0_5_X_fillDTableX6LevelN(HUF_0_5_X_DDescX6* DDescription, HUF_0_5_X_DSeqX6* DSequence, int sizeLog,
                            const rankVal_t rankValOrigin, const U32 consumed, const int minWeight, const U32 maxWeight,
                            const sortedSymbol_t* sortedSymbols, const U32 sortedListSize, const U32* rankStart,
-                           const U32 nbBitsBaseline, HUF_DSeqX6 baseSeq, HUF_DDescX6 DDesc)
+                           const U32 nbBitsBaseline, HUF_0_5_X_DSeqX6 baseSeq, HUF_0_5_X_DDescX6 DDesc)
 {
     const int scaleLog = nbBitsBaseline - sizeLog;   /* note : targetLog >= (nbBitsBaseline-1), hence scaleLog <= 1 */
     const int minBits  = nbBitsBaseline - maxWeight;
     const U32 level = DDesc.nbBytes;
-    U32 rankVal[HUF_ABSOLUTEMAX_TABLELOG + 1];
+    U32 rankVal[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1];
     U32 symbolStartPos, s;
 
     /* local rankVal, will be modified */
@@ -1342,7 +1342,7 @@ static void HUF_fillDTableX6LevelN(HUF_DDescX6* DDescription, HUF_DSeqX6* DSeque
         if ((level<3) && (sizeLog-totalBits >= minBits)) {  /* enough room for another symbol */
             int nextMinWeight = totalBits + scaleLog;
             if (nextMinWeight < 1) nextMinWeight = 1;
-            HUF_fillDTableX6LevelN(DDescription+start, DSequence+start, sizeLog-nbBits,
+            HUF_0_5_X_fillDTableX6LevelN(DDescription+start, DSequence+start, sizeLog-nbBits,
                            rankValOrigin, totalBits, nextMinWeight, maxWeight,
                            sortedSymbols, sortedListSize, rankStart,
                            nbBitsBaseline, baseSeq, DDesc);   /* recursive (max : level 3) */
@@ -1359,23 +1359,23 @@ static void HUF_fillDTableX6LevelN(HUF_DDescX6* DDescription, HUF_DSeqX6* DSeque
 
 
 /* note : same preparation as X4 */
-size_t HUF_readDTableX6 (U32* DTable, const void* src, size_t srcSize)
+size_t HUF_0_5_X_readDTableX6 (U32* DTable, const void* src, size_t srcSize)
 {
-    BYTE weightList[HUF_MAX_SYMBOL_VALUE + 1];
-    sortedSymbol_t sortedSymbol[HUF_MAX_SYMBOL_VALUE + 1];
-    U32 rankStats[HUF_ABSOLUTEMAX_TABLELOG + 1] = { 0 };
-    U32 rankStart0[HUF_ABSOLUTEMAX_TABLELOG + 2] = { 0 };
+    BYTE weightList[HUF_0_5_X_MAX_SYMBOL_VALUE + 1];
+    sortedSymbol_t sortedSymbol[HUF_0_5_X_MAX_SYMBOL_VALUE + 1];
+    U32 rankStats[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1] = { 0 };
+    U32 rankStart0[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 2] = { 0 };
     U32* const rankStart = rankStart0+1;
     U32 tableLog, maxW, sizeOfSort, nbSymbols;
     rankVal_t rankVal;
     const U32 memLog = DTable[0];
     size_t iSize;
 
-    if (memLog > HUF_ABSOLUTEMAX_TABLELOG) return ERROR(tableLog_tooLarge);
+    if (memLog > HUF_0_5_X_ABSOLUTEMAX_TABLELOG) return ERROR(tableLog_tooLarge);
     //memset(weightList, 0, sizeof(weightList));   /* is not necessary, even though some analyzer complain ... */
 
-    iSize = HUF_readStats(weightList, HUF_MAX_SYMBOL_VALUE + 1, rankStats, &nbSymbols, &tableLog, src, srcSize);
-    if (HUF_isError(iSize)) return iSize;
+    iSize = HUF_0_5_X_readStats(weightList, HUF_0_5_X_MAX_SYMBOL_VALUE + 1, rankStats, &nbSymbols, &tableLog, src, srcSize);
+    if (HUF_0_5_X_isError(iSize)) return iSize;
 
     /* check result */
     if (tableLog > memLog) return ERROR(tableLog_tooLarge);   /* DTable is too small */
@@ -1428,16 +1428,16 @@ size_t HUF_readDTableX6 (U32* DTable, const void* src, size_t srcSize)
     /* fill tables */
     {
         void* ddPtr = DTable+1;
-        HUF_DDescX6* DDescription = (HUF_DDescX6*)ddPtr;
+        HUF_0_5_X_DDescX6* DDescription = (HUF_0_5_X_DDescX6*)ddPtr;
         void* dsPtr = DTable + 1 + ((size_t)1<<(memLog-1));
-        HUF_DSeqX6* DSequence = (HUF_DSeqX6*)dsPtr;
-        HUF_DSeqX6 DSeq;
-        HUF_DDescX6 DDesc;
+        HUF_0_5_X_DSeqX6* DSequence = (HUF_0_5_X_DSeqX6*)dsPtr;
+        HUF_0_5_X_DSeqX6 DSeq;
+        HUF_0_5_X_DDescX6 DDesc;
         DSeq.sequence = 0;
         DDesc.nbBits = 0;
         DDesc.nbBytes = 0;
-        HUF_fillDTableX6LevelN(DDescription, DSequence, memLog,
-                       (const U32 (*)[HUF_ABSOLUTEMAX_TABLELOG + 1])rankVal, 0, 1, maxW,
+        HUF_0_5_X_fillDTableX6LevelN(DDescription, DSequence, memLog,
+                       (const U32 (*)[HUF_0_5_X_ABSOLUTEMAX_TABLELOG + 1])rankVal, 0, 1, maxW,
                        sortedSymbol, sizeOfSort, rankStart0,
                        tableLog+1, DSeq, DDesc);
     }
@@ -1446,16 +1446,16 @@ size_t HUF_readDTableX6 (U32* DTable, const void* src, size_t srcSize)
 }
 
 
-static U32 HUF_decodeSymbolX6(void* op, BIT_DStream_t* DStream, const HUF_DDescX6* dd, const HUF_DSeqX6* ds, const U32 dtLog)
+static U32 HUF_0_5_X_decodeSymbolX6(void* op, BIT_DStream_t* DStream, const HUF_0_5_X_DDescX6* dd, const HUF_0_5_X_DSeqX6* ds, const U32 dtLog)
 {
     const size_t val = BIT_lookBitsFast(DStream, dtLog);   /* note : dtLog >= 1 */
-    memcpy(op, ds+val, sizeof(HUF_DSeqX6));
+    memcpy(op, ds+val, sizeof(HUF_0_5_X_DSeqX6));
     BIT_skipBits(DStream, dd[val].nbBits);
     return dd[val].nbBytes;
 }
 
-static U32 HUF_decodeLastSymbolsX6(void* op, const U32 maxL, BIT_DStream_t* DStream,
-                                  const HUF_DDescX6* dd, const HUF_DSeqX6* ds, const U32 dtLog)
+static U32 HUF_0_5_X_decodeLastSymbolsX6(void* op, const U32 maxL, BIT_DStream_t* DStream,
+                                  const HUF_0_5_X_DDescX6* dd, const HUF_0_5_X_DSeqX6* ds, const U32 dtLog)
 {
     const size_t val = BIT_lookBitsFast(DStream, dtLog);   /* note : dtLog >= 1 */
     U32 length = dd[val].nbBytes;
@@ -1474,45 +1474,45 @@ static U32 HUF_decodeLastSymbolsX6(void* op, const U32 maxL, BIT_DStream_t* DStr
 }
 
 
-#define HUF_DECODE_SYMBOLX6_0(ptr, DStreamPtr) \
-    ptr += HUF_decodeSymbolX6(ptr, DStreamPtr, dd, ds, dtLog)
+#define HUF_0_5_X_DECODE_SYMBOLX6_0(ptr, DStreamPtr) \
+    ptr += HUF_0_5_X_decodeSymbolX6(ptr, DStreamPtr, dd, ds, dtLog)
 
-#define HUF_DECODE_SYMBOLX6_1(ptr, DStreamPtr) \
-    if (MEM_64bits() || (HUF_MAX_TABLELOG<=12)) \
-        HUF_DECODE_SYMBOLX6_0(ptr, DStreamPtr)
+#define HUF_0_5_X_DECODE_SYMBOLX6_1(ptr, DStreamPtr) \
+    if (MEM_64bits() || (HUF_0_5_X_MAX_TABLELOG<=12)) \
+        HUF_0_5_X_DECODE_SYMBOLX6_0(ptr, DStreamPtr)
 
-#define HUF_DECODE_SYMBOLX6_2(ptr, DStreamPtr) \
+#define HUF_0_5_X_DECODE_SYMBOLX6_2(ptr, DStreamPtr) \
     if (MEM_64bits()) \
-        HUF_DECODE_SYMBOLX6_0(ptr, DStreamPtr)
+        HUF_0_5_X_DECODE_SYMBOLX6_0(ptr, DStreamPtr)
 
-static inline size_t HUF_decodeStreamX6(BYTE* p, BIT_DStream_t* bitDPtr, BYTE* const pEnd, const U32* DTable, const U32 dtLog)
+static inline size_t HUF_0_5_X_decodeStreamX6(BYTE* p, BIT_DStream_t* bitDPtr, BYTE* const pEnd, const U32* DTable, const U32 dtLog)
 {
     const void* const ddPtr = DTable+1;
-    const HUF_DDescX6* dd = (const HUF_DDescX6*)ddPtr;
+    const HUF_0_5_X_DDescX6* dd = (const HUF_0_5_X_DDescX6*)ddPtr;
     const void* const dsPtr = DTable + 1 + ((size_t)1<<(dtLog-1));
-    const HUF_DSeqX6* ds = (const HUF_DSeqX6*)dsPtr;
+    const HUF_0_5_X_DSeqX6* ds = (const HUF_0_5_X_DSeqX6*)dsPtr;
     BYTE* const pStart = p;
 
     /* up to 16 symbols at a time */
     while ((BIT_reloadDStream(bitDPtr) == BIT_DStream_unfinished) && (p <= pEnd-16)) {
-        HUF_DECODE_SYMBOLX6_2(p, bitDPtr);
-        HUF_DECODE_SYMBOLX6_1(p, bitDPtr);
-        HUF_DECODE_SYMBOLX6_2(p, bitDPtr);
-        HUF_DECODE_SYMBOLX6_0(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX6_1(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX6_0(p, bitDPtr);
     }
 
     /* closer to the end, up to 4 symbols at a time */
     while ((BIT_reloadDStream(bitDPtr) == BIT_DStream_unfinished) && (p <= pEnd-4))
-        HUF_DECODE_SYMBOLX6_0(p, bitDPtr);
+        HUF_0_5_X_DECODE_SYMBOLX6_0(p, bitDPtr);
 
     while ((BIT_reloadDStream(bitDPtr) <= BIT_DStream_endOfBuffer) && (p < pEnd))
-        p += HUF_decodeLastSymbolsX6(p, (U32)(pEnd-p), bitDPtr, dd, ds, dtLog);
+        p += HUF_0_5_X_decodeLastSymbolsX6(p, (U32)(pEnd-p), bitDPtr, dd, ds, dtLog);
 
     return p-pStart;
 }
 
 
-size_t HUF_decompress1X6_usingDTable(
+size_t HUF_0_5_X_decompress1X6_usingDTable(
           void* dst,  size_t dstSize,
     const void* cSrc, size_t cSrcSize,
     const U32* DTable)
@@ -1527,10 +1527,10 @@ size_t HUF_decompress1X6_usingDTable(
     /* Init */
     BIT_DStream_t bitD;
     errorCode = BIT_initDStream(&bitD, istart, cSrcSize);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
 
     /* finish bitStreams one by one */
-    HUF_decodeStreamX6(ostart, &bitD, oend, DTable, dtLog);
+    HUF_0_5_X_decodeStreamX6(ostart, &bitD, oend, DTable, dtLog);
 
     /* check */
     if (!BIT_endOfDStream(&bitD)) return ERROR(corruption_detected);
@@ -1539,22 +1539,22 @@ size_t HUF_decompress1X6_usingDTable(
     return dstSize;
 }
 
-size_t HUF_decompress1X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
+size_t HUF_0_5_X_decompress1X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
 {
-    HUF_CREATE_STATIC_DTABLEX6(DTable, HUF_MAX_TABLELOG);
+    HUF_0_5_X_CREATE_STATIC_DTABLEX6(DTable, HUF_0_5_X_MAX_TABLELOG);
     const BYTE* ip = (const BYTE*) cSrc;
 
-    size_t hSize = HUF_readDTableX6 (DTable, cSrc, cSrcSize);
-    if (HUF_isError(hSize)) return hSize;
+    size_t hSize = HUF_0_5_X_readDTableX6 (DTable, cSrc, cSrcSize);
+    if (HUF_0_5_X_isError(hSize)) return hSize;
     if (hSize >= cSrcSize) return ERROR(srcSize_wrong);
     ip += hSize;
     cSrcSize -= hSize;
 
-    return HUF_decompress1X6_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
+    return HUF_0_5_X_decompress1X6_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
 }
 
 
-size_t HUF_decompress4X6_usingDTable(
+size_t HUF_0_5_X_decompress4X6_usingDTable(
           void* dst,  size_t dstSize,
     const void* cSrc, size_t cSrcSize,
     const U32* DTable)
@@ -1565,9 +1565,9 @@ size_t HUF_decompress4X6_usingDTable(
 
     const U32 dtLog = DTable[0];
     const void* const ddPtr = DTable+1;
-    const HUF_DDescX6* dd = (const HUF_DDescX6*)ddPtr;
+    const HUF_0_5_X_DDescX6* dd = (const HUF_0_5_X_DDescX6*)ddPtr;
     const void* const dsPtr = DTable + 1 + ((size_t)1<<(dtLog-1));
-    const HUF_DSeqX6* ds = (const HUF_DSeqX6*)dsPtr;
+    const HUF_0_5_X_DSeqX6* ds = (const HUF_0_5_X_DSeqX6*)dsPtr;
     size_t errorCode;
 
     /* Check */
@@ -1599,33 +1599,33 @@ size_t HUF_decompress4X6_usingDTable(
     length4 = cSrcSize - (length1 + length2 + length3 + 6);
     if (length4 > cSrcSize) return ERROR(corruption_detected);   /* overflow */
     errorCode = BIT_initDStream(&bitD1, istart1, length1);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     errorCode = BIT_initDStream(&bitD2, istart2, length2);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     errorCode = BIT_initDStream(&bitD3, istart3, length3);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
     errorCode = BIT_initDStream(&bitD4, istart4, length4);
-    if (HUF_isError(errorCode)) return errorCode;
+    if (HUF_0_5_X_isError(errorCode)) return errorCode;
 
     /* 16-64 symbols per loop (4-16 symbols per stream) */
     endSignal = BIT_reloadDStream(&bitD1) | BIT_reloadDStream(&bitD2) | BIT_reloadDStream(&bitD3) | BIT_reloadDStream(&bitD4);
     for ( ; (op3 <= opStart4) && (endSignal==BIT_DStream_unfinished) && (op4<=(oend-16)) ; ) {
-        HUF_DECODE_SYMBOLX6_2(op1, &bitD1);
-        HUF_DECODE_SYMBOLX6_2(op2, &bitD2);
-        HUF_DECODE_SYMBOLX6_2(op3, &bitD3);
-        HUF_DECODE_SYMBOLX6_2(op4, &bitD4);
-        HUF_DECODE_SYMBOLX6_1(op1, &bitD1);
-        HUF_DECODE_SYMBOLX6_1(op2, &bitD2);
-        HUF_DECODE_SYMBOLX6_1(op3, &bitD3);
-        HUF_DECODE_SYMBOLX6_1(op4, &bitD4);
-        HUF_DECODE_SYMBOLX6_2(op1, &bitD1);
-        HUF_DECODE_SYMBOLX6_2(op2, &bitD2);
-        HUF_DECODE_SYMBOLX6_2(op3, &bitD3);
-        HUF_DECODE_SYMBOLX6_2(op4, &bitD4);
-        HUF_DECODE_SYMBOLX6_0(op1, &bitD1);
-        HUF_DECODE_SYMBOLX6_0(op2, &bitD2);
-        HUF_DECODE_SYMBOLX6_0(op3, &bitD3);
-        HUF_DECODE_SYMBOLX6_0(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX6_1(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX6_1(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX6_1(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX6_1(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX6_2(op4, &bitD4);
+        HUF_0_5_X_DECODE_SYMBOLX6_0(op1, &bitD1);
+        HUF_0_5_X_DECODE_SYMBOLX6_0(op2, &bitD2);
+        HUF_0_5_X_DECODE_SYMBOLX6_0(op3, &bitD3);
+        HUF_0_5_X_DECODE_SYMBOLX6_0(op4, &bitD4);
 
         endSignal = BIT_reloadDStream(&bitD1) | BIT_reloadDStream(&bitD2) | BIT_reloadDStream(&bitD3) | BIT_reloadDStream(&bitD4);
     }
@@ -1637,10 +1637,10 @@ size_t HUF_decompress4X6_usingDTable(
     /* note : op4 supposed already verified within main loop */
 
     /* finish bitStreams one by one */
-    HUF_decodeStreamX6(op1, &bitD1, opStart2, DTable, dtLog);
-    HUF_decodeStreamX6(op2, &bitD2, opStart3, DTable, dtLog);
-    HUF_decodeStreamX6(op3, &bitD3, opStart4, DTable, dtLog);
-    HUF_decodeStreamX6(op4, &bitD4, oend,     DTable, dtLog);
+    HUF_0_5_X_decodeStreamX6(op1, &bitD1, opStart2, DTable, dtLog);
+    HUF_0_5_X_decodeStreamX6(op2, &bitD2, opStart3, DTable, dtLog);
+    HUF_0_5_X_decodeStreamX6(op3, &bitD3, opStart4, DTable, dtLog);
+    HUF_0_5_X_decodeStreamX6(op4, &bitD4, oend,     DTable, dtLog);
 
     /* check */
     endSignal = BIT_endOfDStream(&bitD1) & BIT_endOfDStream(&bitD2) & BIT_endOfDStream(&bitD3) & BIT_endOfDStream(&bitD4);
@@ -1651,18 +1651,18 @@ size_t HUF_decompress4X6_usingDTable(
 }
 
 
-size_t HUF_decompress4X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
+size_t HUF_0_5_X_decompress4X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
 {
-    HUF_CREATE_STATIC_DTABLEX6(DTable, HUF_MAX_TABLELOG);
+    HUF_0_5_X_CREATE_STATIC_DTABLEX6(DTable, HUF_0_5_X_MAX_TABLELOG);
     const BYTE* ip = (const BYTE*) cSrc;
 
-    size_t hSize = HUF_readDTableX6 (DTable, cSrc, cSrcSize);
-    if (HUF_isError(hSize)) return hSize;
+    size_t hSize = HUF_0_5_X_readDTableX6 (DTable, cSrc, cSrcSize);
+    if (HUF_0_5_X_isError(hSize)) return hSize;
     if (hSize >= cSrcSize) return ERROR(srcSize_wrong);
     ip += hSize;
     cSrcSize -= hSize;
 
-    return HUF_decompress4X6_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
+    return HUF_0_5_X_decompress4X6_usingDTable (dst, dstSize, ip, cSrcSize, DTable);
 }
 
 
@@ -1694,9 +1694,9 @@ static const algo_time_t algoTime[16 /* Quantization */][3 /* single, double, qu
 
 typedef size_t (*decompressionAlgo)(void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);
 
-size_t HUF_decompress (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
+size_t HUF_0_5_X_decompress (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize)
 {
-    static const decompressionAlgo decompress[3] = { HUF_decompress4X2, HUF_decompress4X4, HUF_decompress4X6 };
+    static const decompressionAlgo decompress[3] = { HUF_0_5_X_decompress4X2, HUF_0_5_X_decompress4X4, HUF_0_5_X_decompress4X6 };
     /* estimate decompression time */
     U32 Q;
     const U32 D256 = (U32)(dstSize >> 8);
@@ -1722,7 +1722,7 @@ size_t HUF_decompress (void* dst, size_t dstSize, const void* cSrc, size_t cSrcS
 
     return decompress[algoNb](dst, dstSize, cSrc, cSrcSize);
 
-    //return HUF_decompress4X2(dst, dstSize, cSrc, cSrcSize);   /* multi-streams single-symbol decoding */
-    //return HUF_decompress4X4(dst, dstSize, cSrc, cSrcSize);   /* multi-streams double-symbols decoding */
-    //return HUF_decompress4X6(dst, dstSize, cSrc, cSrcSize);   /* multi-streams quad-symbols decoding */
+    //return HUF_0_5_X_decompress4X2(dst, dstSize, cSrc, cSrcSize);   /* multi-streams single-symbol decoding */
+    //return HUF_0_5_X_decompress4X4(dst, dstSize, cSrc, cSrcSize);   /* multi-streams double-symbols decoding */
+    //return HUF_0_5_X_decompress4X6(dst, dstSize, cSrc, cSrcSize);   /* multi-streams quad-symbols decoding */
 }

--- a/huff0.h
+++ b/huff0.h
@@ -48,46 +48,46 @@ extern "C" {
 /* ****************************************
 *  Huff0 simple functions
 ******************************************/
-size_t HUF_compress(void* dst, size_t maxDstSize,
+size_t HUF_0_5_X_compress(void* dst, size_t maxDstSize,
               const void* src, size_t srcSize);
-size_t HUF_decompress(void* dst,  size_t dstSize,
+size_t HUF_0_5_X_decompress(void* dst,  size_t dstSize,
                 const void* cSrc, size_t cSrcSize);
 /*!
-HUF_compress():
+HUF_0_5_X_compress():
     Compress content of buffer 'src', of size 'srcSize', into destination buffer 'dst'.
-    'dst' buffer must be already allocated. Compression runs faster if maxDstSize >= HUF_compressBound(srcSize).
+    'dst' buffer must be already allocated. Compression runs faster if maxDstSize >= HUF_0_5_X_compressBound(srcSize).
     Note : srcSize must be <= 128 KB
     @return : size of compressed data (<= maxDstSize)
     Special values : if return == 0, srcData is not compressible => Nothing is stored within dst !!!
                      if return == 1, srcData is a single repeated byte symbol (RLE compression)
-                     if HUF_isError(return), compression failed (more details using HUF_getErrorName())
+                     if HUF_0_5_X_isError(return), compression failed (more details using HUF_0_5_X_getErrorName())
 
-HUF_decompress():
+HUF_0_5_X_decompress():
     Decompress Huff0 data from buffer 'cSrc', of size 'cSrcSize',
     into already allocated destination buffer 'dst', of size 'dstSize'.
     @dstSize : must be the **exact** size of original (uncompressed) data.
-    Note : in contrast with FSE, HUF_decompress can regenerate
+    Note : in contrast with FSE, HUF_0_5_X_decompress can regenerate
            RLE (cSrcSize==1) and uncompressed (cSrcSize==dstSize) data,
            because it knows size to regenerate.
     @return : size of regenerated data (== dstSize)
-              or an error code, which can be tested using HUF_isError()
+              or an error code, which can be tested using HUF_0_5_X_isError()
 */
 
 
 /* ****************************************
 *  Tool functions
 ******************************************/
-size_t HUF_compressBound(size_t size);       /* maximum compressed size */
+size_t HUF_0_5_X_compressBound(size_t size);       /* maximum compressed size */
 
 /* Error Management */
-unsigned    HUF_isError(size_t code);        /* tells if a return value is an error code */
-const char* HUF_getErrorName(size_t code);   /* provides error code string (useful for debugging) */
+unsigned    HUF_0_5_X_isError(size_t code);        /* tells if a return value is an error code */
+const char* HUF_0_5_X_getErrorName(size_t code);   /* provides error code string (useful for debugging) */
 
 
 /* ****************************************
 *  Advanced functions
 ******************************************/
-size_t HUF_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog);
+size_t HUF_0_5_X_compress2 (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog);
 
 
 #if defined (__cplusplus)

--- a/huff0_static.h
+++ b/huff0_static.h
@@ -49,87 +49,87 @@ extern "C" {
 *  Static allocation
 ******************************************/
 /* Huff0 buffer bounds */
-#define HUF_CTABLEBOUND 129
-#define HUF_BLOCKBOUND(size) (size + (size>>8) + 8)   /* only true if incompressible pre-filtered with fast heuristic */
-#define HUF_COMPRESSBOUND(size) (HUF_CTABLEBOUND + HUF_BLOCKBOUND(size))   /* Macro version, useful for static allocation */
+#define HUF_0_5_X_CTABLEBOUND 129
+#define HUF_0_5_X_BLOCKBOUND(size) (size + (size>>8) + 8)   /* only true if incompressible pre-filtered with fast heuristic */
+#define HUF_0_5_X_COMPRESSBOUND(size) (HUF_0_5_X_CTABLEBOUND + HUF_0_5_X_BLOCKBOUND(size))   /* Macro version, useful for static allocation */
 
 /* static allocation of Huff0's Compression Table */
-#define HUF_CREATE_STATIC_CTABLE(name, maxSymbolValue) \
+#define HUF_0_5_X_CREATE_STATIC_CTABLE(name, maxSymbolValue) \
     U32 name##hb[maxSymbolValue+1]; \
     void* name##hv = &(name##hb); \
-    HUF_CElt* name = (HUF_CElt*)(name##hv)   /* no final ; */
+    HUF_0_5_X_CElt* name = (HUF_0_5_X_CElt*)(name##hv)   /* no final ; */
 
 /* static allocation of Huff0's DTable */
-#define HUF_DTABLE_SIZE(maxTableLog)   (1 + (1<<maxTableLog))
-#define HUF_CREATE_STATIC_DTABLEX2(DTable, maxTableLog) \
-        unsigned short DTable[HUF_DTABLE_SIZE(maxTableLog)] = { maxTableLog }
-#define HUF_CREATE_STATIC_DTABLEX4(DTable, maxTableLog) \
-        unsigned int DTable[HUF_DTABLE_SIZE(maxTableLog)] = { maxTableLog }
-#define HUF_CREATE_STATIC_DTABLEX6(DTable, maxTableLog) \
-        unsigned int DTable[HUF_DTABLE_SIZE(maxTableLog) * 3 / 2] = { maxTableLog }
+#define HUF_0_5_X_DTABLE_SIZE(maxTableLog)   (1 + (1<<maxTableLog))
+#define HUF_0_5_X_CREATE_STATIC_DTABLEX2(DTable, maxTableLog) \
+        unsigned short DTable[HUF_0_5_X_DTABLE_SIZE(maxTableLog)] = { maxTableLog }
+#define HUF_0_5_X_CREATE_STATIC_DTABLEX4(DTable, maxTableLog) \
+        unsigned int DTable[HUF_0_5_X_DTABLE_SIZE(maxTableLog)] = { maxTableLog }
+#define HUF_0_5_X_CREATE_STATIC_DTABLEX6(DTable, maxTableLog) \
+        unsigned int DTable[HUF_0_5_X_DTABLE_SIZE(maxTableLog) * 3 / 2] = { maxTableLog }
 
 
 /* ****************************************
 *  Advanced decompression functions
 ******************************************/
-size_t HUF_decompress4X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* single-symbol decoder */
-size_t HUF_decompress4X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* double-symbols decoder */
-size_t HUF_decompress4X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* quad-symbols decoder */
+size_t HUF_0_5_X_decompress4X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* single-symbol decoder */
+size_t HUF_0_5_X_decompress4X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* double-symbols decoder */
+size_t HUF_0_5_X_decompress4X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* quad-symbols decoder */
 
 
 /* ****************************************
 *  Huff0 detailed API
 ******************************************/
 /*!
-HUF_compress() does the following:
-1. count symbol occurrence from source[] into table count[] using FSE_count()
-2. build Huffman table from count using HUF_buildCTable()
-3. save Huffman table to memory buffer using HUF_writeCTable()
-4. encode the data stream using HUF_compress_usingCTable()
+HUF_0_5_X_compress() does the following:
+1. count symbol occurrence from source[] into table count[] using FSE_0_5_X_count()
+2. build Huffman table from count using HUF_0_5_X_buildCTable()
+3. save Huffman table to memory buffer using HUF_0_5_X_writeCTable()
+4. encode the data stream using HUF_0_5_X_compress_usingCTable()
 
 The following API allows targeting specific sub-functions for advanced tasks.
 For example, it's possible to compress several blocks using the same 'CTable',
 or to save and regenerate 'CTable' using external methods.
 */
-/* FSE_count() : find it within "fse.h" */
-typedef struct HUF_CElt_s HUF_CElt;   /* incomplete type */
-size_t HUF_buildCTable (HUF_CElt* CTable, const unsigned* count, unsigned maxSymbolValue, unsigned maxNbBits);
-size_t HUF_writeCTable (void* dst, size_t maxDstSize, const HUF_CElt* CTable, unsigned maxSymbolValue, unsigned huffLog);
-size_t HUF_compress4X_into4Segments(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_CElt* CTable);
+/* FSE_0_5_X_count() : find it within "fse.h" */
+typedef struct HUF_0_5_X_CElt_s HUF_0_5_X_CElt;   /* incomplete type */
+size_t HUF_0_5_X_buildCTable (HUF_0_5_X_CElt* CTable, const unsigned* count, unsigned maxSymbolValue, unsigned maxNbBits);
+size_t HUF_0_5_X_writeCTable (void* dst, size_t maxDstSize, const HUF_0_5_X_CElt* CTable, unsigned maxSymbolValue, unsigned huffLog);
+size_t HUF_0_5_X_compress4X_into4Segments(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_0_5_X_CElt* CTable);
 
 
 /*!
-HUF_decompress() does the following:
+HUF_0_5_X_decompress() does the following:
 1. select the decompression algorithm (X2, X4, X6) based on pre-computed heuristics
-2. build Huffman table from save, using HUF_readDTableXn()
-3. decode 1 or 4 segments in parallel using HUF_decompressSXn_usingDTable
+2. build Huffman table from save, using HUF_0_5_X_readDTableXn()
+3. decode 1 or 4 segments in parallel using HUF_0_5_X_decompressSXn_usingDTable
 */
-size_t HUF_readDTableX2 (unsigned short* DTable, const void* src, size_t srcSize);
-size_t HUF_readDTableX4 (unsigned* DTable, const void* src, size_t srcSize);
-size_t HUF_readDTableX6 (unsigned* DTable, const void* src, size_t srcSize);
+size_t HUF_0_5_X_readDTableX2 (unsigned short* DTable, const void* src, size_t srcSize);
+size_t HUF_0_5_X_readDTableX4 (unsigned* DTable, const void* src, size_t srcSize);
+size_t HUF_0_5_X_readDTableX6 (unsigned* DTable, const void* src, size_t srcSize);
 
-size_t HUF_decompress4X2_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned short* DTable);
-size_t HUF_decompress4X4_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
-size_t HUF_decompress4X6_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
+size_t HUF_0_5_X_decompress4X2_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned short* DTable);
+size_t HUF_0_5_X_decompress4X4_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
+size_t HUF_0_5_X_decompress4X6_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
 
 
 /* single stream variants */
 
-size_t HUF_compress1X (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog);
-size_t HUF_compress1X_usingCTable(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_CElt* CTable);
+size_t HUF_0_5_X_compress1X (void* dst, size_t dstSize, const void* src, size_t srcSize, unsigned maxSymbolValue, unsigned tableLog);
+size_t HUF_0_5_X_compress1X_usingCTable(void* dst, size_t dstSize, const void* src, size_t srcSize, const HUF_0_5_X_CElt* CTable);
 
-size_t HUF_decompress1X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* single-symbol decoder */
-size_t HUF_decompress1X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* double-symbol decoder */
-size_t HUF_decompress1X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* quad-symbol decoder */
+size_t HUF_0_5_X_decompress1X2 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* single-symbol decoder */
+size_t HUF_0_5_X_decompress1X4 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* double-symbol decoder */
+size_t HUF_0_5_X_decompress1X6 (void* dst, size_t dstSize, const void* cSrc, size_t cSrcSize);   /* quad-symbol decoder */
 
-size_t HUF_decompress1X2_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned short* DTable);
-size_t HUF_decompress1X4_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
-size_t HUF_decompress1X6_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
+size_t HUF_0_5_X_decompress1X2_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned short* DTable);
+size_t HUF_0_5_X_decompress1X4_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
+size_t HUF_0_5_X_decompress1X6_usingDTable(void* dst, size_t maxDstSize, const void* cSrc, size_t cSrcSize, const unsigned* DTable);
 
 
-/* Loading a CTable saved with HUF_writeCTable() */
+/* Loading a CTable saved with HUF_0_5_X_writeCTable() */
 
-size_t HUF_readCTable (HUF_CElt* CTable, unsigned maxSymbolValue, const void* src, size_t srcSize);
+size_t HUF_0_5_X_readCTable (HUF_0_5_X_CElt* CTable, unsigned maxSymbolValue, const void* src, size_t srcSize);
 
 
 #if defined (__cplusplus)

--- a/sssort.c
+++ b/sssort.c
@@ -773,7 +773,7 @@ ss_swapmerge(const sauchar_t *T, const saidx_t *PA,
 
 /* Substring sort */
 void
-sssort(const sauchar_t *T, const saidx_t *PA,
+sssort_0_5_x(const sauchar_t *T, const saidx_t *PA,
        saidx_t *first, saidx_t *last,
        saidx_t *buf, saidx_t bufsize,
        saidx_t depth, saidx_t n, saint_t lastsuffix) {

--- a/zstd.go
+++ b/zstd.go
@@ -1,4 +1,4 @@
-package zstd
+package zstd_0_5_x
 
 /*
 #include "zstd.h"
@@ -83,7 +83,7 @@ func CompressBound(srcSize int) int {
 
 // cCompressBound is a cgo call to check the go implementation above against the c code.
 func cCompressBound(srcSize int) int {
-	return int(C.ZSTD_compressBound(C.size_t(srcSize)))
+	return int(C.ZSTD_0_5_X_compressBound(C.size_t(srcSize)))
 }
 
 // getError returns an error for the return code, or nil if it's not an error
@@ -95,7 +95,7 @@ func getError(code int) error {
 }
 
 func cIsError(code int) bool {
-	return int(C.ZSTD_isError(C.size_t(code))) != 0
+	return int(C.ZSTD_0_5_X_isError(C.size_t(code))) != 0
 }
 
 // Compress src into dst.  If you have a buffer to use, you can pass it to
@@ -116,7 +116,7 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 
 	var cWritten C.size_t
 	if len(src) > 0 {
-		cWritten = C.ZSTD_compress(
+		cWritten = C.ZSTD_0_5_X_compress(
 			unsafe.Pointer(&dst[0]),
 			C.size_t(len(dst)),
 			unsafe.Pointer(&src[0]),
@@ -127,7 +127,7 @@ func CompressLevel(dst, src []byte, level int) ([]byte, error) {
 		// If you refactor this, careful not to store unsafe.Pointer(nil) in a
 		// variable or else you'll hit
 		// https://github.com/golang/go/issues/28606
-		cWritten = C.ZSTD_compress(
+		cWritten = C.ZSTD_0_5_X_compress(
 			unsafe.Pointer(&dst[0]),
 			C.size_t(len(dst)),
 			unsafe.Pointer(nil),
@@ -155,7 +155,7 @@ func Decompress(dst, src []byte) ([]byte, error) {
 	}
 	decompress := func(dst, src []byte) ([]byte, error) {
 
-		cWritten := C.ZSTD_decompress(
+		cWritten := C.ZSTD_0_5_X_decompress(
 			unsafe.Pointer(&dst[0]),
 			C.size_t(len(dst)),
 			unsafe.Pointer(&src[0]),

--- a/zstd.go
+++ b/zstd.go
@@ -1,4 +1,4 @@
-package zstd_0_5_x
+package zstd_0
 
 /*
 #include "zstd.h"

--- a/zstd.h
+++ b/zstd.h
@@ -29,8 +29,8 @@
     You can contact the author at :
     - zstd source repository : https://github.com/Cyan4973/zstd
 */
-#ifndef ZSTD_H
-#define ZSTD_H
+#ifndef ZSTD_0_5_X_H
+#define ZSTD_0_5_X_H
 
 #if defined (__cplusplus)
 extern "C" {
@@ -47,10 +47,10 @@ extern "C" {
 *  Export parameters
 *****************************************************************/
 /*!
-*  ZSTD_DLL_EXPORT :
+*  ZSTD_0_5_X_DLL_EXPORT :
 *  Enable exporting of functions when building a Windows DLL
 */
-#if defined(_WIN32) && defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#if defined(_WIN32) && defined(ZSTD_0_5_X_DLL_EXPORT) && (ZSTD_0_5_X_DLL_EXPORT==1)
 #  define ZSTDLIB_API __declspec(dllexport)
 #else
 #  define ZSTDLIB_API
@@ -60,84 +60,84 @@ extern "C" {
 /* *************************************
 *  Version
 ***************************************/
-#define ZSTD_VERSION_MAJOR    0    /* for breaking interface changes  */
-#define ZSTD_VERSION_MINOR    5    /* for new (non-breaking) interface capabilities */
-#define ZSTD_VERSION_RELEASE  0    /* for tweaks, bug-fixes, or development */
-#define ZSTD_VERSION_NUMBER  (ZSTD_VERSION_MAJOR *100*100 + ZSTD_VERSION_MINOR *100 + ZSTD_VERSION_RELEASE)
-ZSTDLIB_API unsigned ZSTD_versionNumber (void);
+#define ZSTD_0_5_X_VERSION_MAJOR    0    /* for breaking interface changes  */
+#define ZSTD_0_5_X_VERSION_MINOR    5    /* for new (non-breaking) interface capabilities */
+#define ZSTD_0_5_X_VERSION_RELEASE  0    /* for tweaks, bug-fixes, or development */
+#define ZSTD_0_5_X_VERSION_NUMBER  (ZSTD_0_5_X_VERSION_MAJOR *100*100 + ZSTD_0_5_X_VERSION_MINOR *100 + ZSTD_0_5_X_VERSION_RELEASE)
+ZSTDLIB_API unsigned ZSTD_0_5_X_versionNumber (void);
 
 
 /* *************************************
 *  Simple functions
 ***************************************/
-/*! ZSTD_compress() :
+/*! ZSTD_0_5_X_compress() :
     Compresses `srcSize` bytes from buffer `src` into buffer `dst` of size `dstCapacity`.
     Destination buffer must be already allocated.
-    Compression runs faster if `dstCapacity` >=  `ZSTD_compressBound(srcSize)`.
+    Compression runs faster if `dstCapacity` >=  `ZSTD_0_5_X_compressBound(srcSize)`.
     @return : the number of bytes written into `dst`,
-              or an error code if it fails (which can be tested using ZSTD_isError()) */
-ZSTDLIB_API size_t ZSTD_compress(   void* dst, size_t dstCapacity,
+              or an error code if it fails (which can be tested using ZSTD_0_5_X_isError()) */
+ZSTDLIB_API size_t ZSTD_0_5_X_compress(   void* dst, size_t dstCapacity,
                               const void* src, size_t srcSize,
                                      int  compressionLevel);
 
-/*! ZSTD_decompress() :
+/*! ZSTD_0_5_X_decompress() :
     `compressedSize` : is the _exact_ size of the compressed blob, otherwise decompression will fail.
     `dstCapacity` must be large enough, equal or larger than originalSize.
     @return : the number of bytes decompressed into `dst` (<= `dstCapacity`),
-              or an errorCode if it fails (which can be tested using ZSTD_isError()) */
-ZSTDLIB_API size_t ZSTD_decompress( void* dst, size_t dstCapacity,
+              or an errorCode if it fails (which can be tested using ZSTD_0_5_X_isError()) */
+ZSTDLIB_API size_t ZSTD_0_5_X_decompress( void* dst, size_t dstCapacity,
                               const void* src, size_t compressedSize);
 
 
 /* *************************************
 *  Helper functions
 ***************************************/
-ZSTDLIB_API size_t      ZSTD_compressBound(size_t srcSize); /*!< maximum compressed size (worst case scenario) */
+ZSTDLIB_API size_t      ZSTD_0_5_X_compressBound(size_t srcSize); /*!< maximum compressed size (worst case scenario) */
 
 /* Error Management */
-ZSTDLIB_API unsigned    ZSTD_isError(size_t code);          /*!< tells if a `size_t` function result is an error code */
-ZSTDLIB_API const char* ZSTD_getErrorName(size_t code);     /*!< provides readable string for an error code */
+ZSTDLIB_API unsigned    ZSTD_0_5_X_isError(size_t code);          /*!< tells if a `size_t` function result is an error code */
+ZSTDLIB_API const char* ZSTD_0_5_X_getErrorName(size_t code);     /*!< provides readable string for an error code */
 
 
 /* *************************************
 *  Explicit memory management
 ***************************************/
 /** Compression context */
-typedef struct ZSTD_CCtx_s ZSTD_CCtx;                       /*< incomplete type */
-ZSTDLIB_API ZSTD_CCtx* ZSTD_createCCtx(void);
-ZSTDLIB_API size_t     ZSTD_freeCCtx(ZSTD_CCtx* cctx);      /*!< @return : errorCode */
+typedef struct ZSTD_0_5_X_CCtx_s ZSTD_0_5_X_CCtx;                       /*< incomplete type */
+ZSTDLIB_API ZSTD_0_5_X_CCtx* ZSTD_0_5_X_createCCtx(void);
+ZSTDLIB_API size_t     ZSTD_0_5_X_freeCCtx(ZSTD_0_5_X_CCtx* cctx);      /*!< @return : errorCode */
 
-/** ZSTD_compressCCtx() :
-    Same as ZSTD_compress(), but requires an already allocated ZSTD_CCtx (see ZSTD_createCCtx()) */
-ZSTDLIB_API size_t ZSTD_compressCCtx(ZSTD_CCtx* ctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize, int compressionLevel);
+/** ZSTD_0_5_X_compressCCtx() :
+    Same as ZSTD_0_5_X_compress(), but requires an already allocated ZSTD_0_5_X_CCtx (see ZSTD_0_5_X_createCCtx()) */
+ZSTDLIB_API size_t ZSTD_0_5_X_compressCCtx(ZSTD_0_5_X_CCtx* ctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize, int compressionLevel);
 
 /** Decompression context */
-typedef struct ZSTD_DCtx_s ZSTD_DCtx;
-ZSTDLIB_API ZSTD_DCtx* ZSTD_createDCtx(void);
-ZSTDLIB_API size_t     ZSTD_freeDCtx(ZSTD_DCtx* dctx);      /*!< @return : errorCode */
+typedef struct ZSTD_0_5_X_DCtx_s ZSTD_0_5_X_DCtx;
+ZSTDLIB_API ZSTD_0_5_X_DCtx* ZSTD_0_5_X_createDCtx(void);
+ZSTDLIB_API size_t     ZSTD_0_5_X_freeDCtx(ZSTD_0_5_X_DCtx* dctx);      /*!< @return : errorCode */
 
-/** ZSTD_decompressDCtx() :
-*   Same as ZSTD_decompress(), but requires an already allocated ZSTD_DCtx (see ZSTD_createDCtx()) */
-ZSTDLIB_API size_t ZSTD_decompressDCtx(ZSTD_DCtx* ctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
+/** ZSTD_0_5_X_decompressDCtx() :
+*   Same as ZSTD_0_5_X_decompress(), but requires an already allocated ZSTD_0_5_X_DCtx (see ZSTD_0_5_X_createDCtx()) */
+ZSTDLIB_API size_t ZSTD_0_5_X_decompressDCtx(ZSTD_0_5_X_DCtx* ctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 
 
 /*-***********************
 *  Dictionary API
 *************************/
-/*! ZSTD_compress_usingDict() :
+/*! ZSTD_0_5_X_compress_usingDict() :
 *   Compression using a pre-defined Dictionary content (see dictBuilder).
-*   Note : dict can be NULL, in which case, it's equivalent to ZSTD_compressCCtx() */
-ZSTDLIB_API size_t ZSTD_compress_usingDict(ZSTD_CCtx* ctx,
+*   Note : dict can be NULL, in which case, it's equivalent to ZSTD_0_5_X_compressCCtx() */
+ZSTDLIB_API size_t ZSTD_0_5_X_compress_usingDict(ZSTD_0_5_X_CCtx* ctx,
                                            void* dst, size_t dstCapacity,
                                      const void* src, size_t srcSize,
                                      const void* dict,size_t dictSize,
                                            int compressionLevel);
 
-/*! ZSTD_decompress_usingDict() :
+/*! ZSTD_0_5_X_decompress_usingDict() :
 *   Decompression using a pre-defined Dictionary content (see dictBuilder).
 *   Dictionary must be identical to the one used during compression, otherwise regenerated data will be corrupted.
-*   Note : dict can be NULL, in which case, it's equivalent to ZSTD_decompressDCtx() */
-ZSTDLIB_API size_t ZSTD_decompress_usingDict(ZSTD_DCtx* dctx,
+*   Note : dict can be NULL, in which case, it's equivalent to ZSTD_0_5_X_decompressDCtx() */
+ZSTDLIB_API size_t ZSTD_0_5_X_decompress_usingDict(ZSTD_0_5_X_DCtx* dctx,
                                              void* dst, size_t dstCapacity,
                                        const void* src, size_t srcSize,
                                        const void* dict,size_t dictSize);
@@ -145,14 +145,14 @@ ZSTDLIB_API size_t ZSTD_decompress_usingDict(ZSTD_DCtx* dctx,
 /* **************************************
 *  Streaming functions (direct mode)
 ****************************************/
-ZSTDLIB_API size_t ZSTD_compressBegin(ZSTD_CCtx* cctx, int compressionLevel);
-ZSTDLIB_API size_t ZSTD_compressBegin_usingDict(ZSTD_CCtx* cctx, const void* dict,size_t dictSize, int compressionLevel);
-ZSTDLIB_API size_t ZSTD_compressContinue(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
-ZSTDLIB_API size_t ZSTD_compressEnd(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressBegin(ZSTD_0_5_X_CCtx* cctx, int compressionLevel);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressBegin_usingDict(ZSTD_0_5_X_CCtx* cctx, const void* dict,size_t dictSize, int compressionLevel);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressContinue(ZSTD_0_5_X_CCtx* cctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressEnd(ZSTD_0_5_X_CCtx* cctx, void* dst, size_t dstCapacity);
 
 
 #if defined (__cplusplus)
 }
 #endif
 
-#endif  /* ZSTD_H */
+#endif  /* ZSTD_0_5_X_H */

--- a/zstd_buffered.c
+++ b/zstd_buffered.c
@@ -47,47 +47,47 @@
 /* *************************************
 *  Constants
 ***************************************/
-static size_t ZBUFF_blockHeaderSize = 3;
-static size_t ZBUFF_endFrameSize = 3;
+static size_t ZBUFF_0_5_X_blockHeaderSize = 3;
+static size_t ZBUFF_0_5_X_endFrameSize = 3;
 
 /** ************************************************
 *  Streaming compression
 *
-*  A ZBUFF_CCtx object is required to track streaming operation.
-*  Use ZBUFF_createCCtx() and ZBUFF_freeCCtx() to create/release resources.
-*  Use ZBUFF_compressInit() to start a new compression operation.
-*  ZBUFF_CCtx objects can be reused multiple times.
+*  A ZBUFF_0_5_X_CCtx object is required to track streaming operation.
+*  Use ZBUFF_0_5_X_createCCtx() and ZBUFF_0_5_X_freeCCtx() to create/release resources.
+*  Use ZBUFF_0_5_X_compressInit() to start a new compression operation.
+*  ZBUFF_0_5_X_CCtx objects can be reused multiple times.
 *
-*  Use ZBUFF_compressContinue() repetitively to consume your input.
+*  Use ZBUFF_0_5_X_compressContinue() repetitively to consume your input.
 *  *srcSizePtr and *maxDstSizePtr can be any size.
 *  The function will report how many bytes were read or written by modifying *srcSizePtr and *maxDstSizePtr.
 *  Note that it may not consume the entire input, in which case it's up to the caller to call again the function with remaining input.
 *  The content of dst will be overwritten (up to *maxDstSizePtr) at each function call, so save its content if it matters or change dst .
 *  @return : a hint to preferred nb of bytes to use as input for next function call (it's only a hint, to improve latency)
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
-*  ZBUFF_compressFlush() can be used to instruct ZBUFF to compress and output whatever remains within its buffer.
+*  ZBUFF_0_5_X_compressFlush() can be used to instruct ZBUFF to compress and output whatever remains within its buffer.
 *  Note that it will not output more than *maxDstSizePtr.
 *  Therefore, some content might still be left into its internal buffer if dst buffer is too small.
 *  @return : nb of bytes still present into internal buffer (0 if it's empty)
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
-*  ZBUFF_compressEnd() instructs to finish a frame.
+*  ZBUFF_0_5_X_compressEnd() instructs to finish a frame.
 *  It will perform a flush and write frame epilogue.
-*  Similar to ZBUFF_compressFlush(), it may not be able to output the entire internal buffer content if *maxDstSizePtr is too small.
+*  Similar to ZBUFF_0_5_X_compressFlush(), it may not be able to output the entire internal buffer content if *maxDstSizePtr is too small.
 *  @return : nb of bytes still present into internal buffer (0 if it's empty)
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
 *  Hint : recommended buffer sizes (not compulsory)
 *  input : 128 KB block size is the internal unit, it improves latency to use this value.
-*  output : ZSTD_compressBound(128 KB) + 3 + 3 : ensures it's always possible to write/flush/end a full block at best speed.
+*  output : ZSTD_0_5_X_compressBound(128 KB) + 3 + 3 : ensures it's always possible to write/flush/end a full block at best speed.
 * **************************************************/
 
-typedef enum { ZBUFFcs_init, ZBUFFcs_load, ZBUFFcs_flush } ZBUFF_cStage;
+typedef enum { ZBUFFcs_init, ZBUFFcs_load, ZBUFFcs_flush } ZBUFF_0_5_X_cStage;
 
 /* *** Ressources *** */
-struct ZBUFF_CCtx_s {
-    ZSTD_CCtx* zc;
+struct ZBUFF_0_5_X_CCtx_s {
+    ZSTD_0_5_X_CCtx* zc;
     char* inBuff;
     size_t inBuffSize;
     size_t inToCompress;
@@ -98,22 +98,22 @@ struct ZBUFF_CCtx_s {
     size_t outBuffSize;
     size_t outBuffContentSize;
     size_t outBuffFlushedSize;
-    ZBUFF_cStage stage;
-};   /* typedef'd tp ZBUFF_CCtx within "zstd_buffered.h" */
+    ZBUFF_0_5_X_cStage stage;
+};   /* typedef'd tp ZBUFF_0_5_X_CCtx within "zstd_buffered.h" */
 
-ZBUFF_CCtx* ZBUFF_createCCtx(void)
+ZBUFF_0_5_X_CCtx* ZBUFF_0_5_X_createCCtx(void)
 {
-    ZBUFF_CCtx* zbc = (ZBUFF_CCtx*)malloc(sizeof(ZBUFF_CCtx));
+    ZBUFF_0_5_X_CCtx* zbc = (ZBUFF_0_5_X_CCtx*)malloc(sizeof(ZBUFF_0_5_X_CCtx));
     if (zbc==NULL) return NULL;
     memset(zbc, 0, sizeof(*zbc));
-    zbc->zc = ZSTD_createCCtx();
+    zbc->zc = ZSTD_0_5_X_createCCtx();
     return zbc;
 }
 
-size_t ZBUFF_freeCCtx(ZBUFF_CCtx* zbc)
+size_t ZBUFF_0_5_X_freeCCtx(ZBUFF_0_5_X_CCtx* zbc)
 {
     if (zbc==NULL) return 0;   /* support free on NULL */
-    ZSTD_freeCCtx(zbc->zc);
+    ZSTD_0_5_X_freeCCtx(zbc->zc);
     free(zbc->inBuff);
     free(zbc->outBuff);
     free(zbc);
@@ -125,11 +125,11 @@ size_t ZBUFF_freeCCtx(ZBUFF_CCtx* zbc)
 
 #define MIN(a,b)    ( ((a)<(b)) ? (a) : (b) )
 #define BLOCKSIZE   (128 * 1024)   /* a bit too "magic", should come from reference */
-size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* zbc, const void* dict, size_t dictSize, ZSTD_parameters params)
+size_t ZBUFF_0_5_X_compressInit_advanced(ZBUFF_0_5_X_CCtx* zbc, const void* dict, size_t dictSize, ZSTD_0_5_X_parameters params)
 {
     size_t neededInBuffSize;
 
-    ZSTD_validateParams(&params);
+    ZSTD_0_5_X_validateParams(&params);
     neededInBuffSize = (size_t)1 << params.windowLog;
 
     /* allocate buffers */
@@ -140,15 +140,15 @@ size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* zbc, const void* dict, size_t dic
         if (zbc->inBuff == NULL) return ERROR(memory_allocation);
     }
     zbc->blockSize = MIN(BLOCKSIZE, zbc->inBuffSize);
-    if (zbc->outBuffSize < ZSTD_compressBound(zbc->blockSize)+1) {
-        zbc->outBuffSize = ZSTD_compressBound(zbc->blockSize)+1;
+    if (zbc->outBuffSize < ZSTD_0_5_X_compressBound(zbc->blockSize)+1) {
+        zbc->outBuffSize = ZSTD_0_5_X_compressBound(zbc->blockSize)+1;
         free(zbc->outBuff);   /* should not be necessary */
         zbc->outBuff = (char*)malloc(zbc->outBuffSize);
         if (zbc->outBuff == NULL) return ERROR(memory_allocation);
     }
 
-    zbc->outBuffContentSize = ZSTD_compressBegin_advanced(zbc->zc, dict, dictSize, params);
-    if (ZSTD_isError(zbc->outBuffContentSize)) return zbc->outBuffContentSize;
+    zbc->outBuffContentSize = ZSTD_0_5_X_compressBegin_advanced(zbc->zc, dict, dictSize, params);
+    if (ZSTD_0_5_X_isError(zbc->outBuffContentSize)) return zbc->outBuffContentSize;
 
     zbc->inToCompress = 0;
     zbc->inBuffPos = 0;
@@ -158,28 +158,28 @@ size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* zbc, const void* dict, size_t dic
     return 0;   /* ready to go */
 }
 
-size_t ZBUFF_compressInit(ZBUFF_CCtx* zbc, int compressionLevel)
+size_t ZBUFF_0_5_X_compressInit(ZBUFF_0_5_X_CCtx* zbc, int compressionLevel)
 {
-    return ZBUFF_compressInit_advanced(zbc, NULL, 0, ZSTD_getParams(compressionLevel, 0));
+    return ZBUFF_0_5_X_compressInit_advanced(zbc, NULL, 0, ZSTD_0_5_X_getParams(compressionLevel, 0));
 }
 
 
-ZSTDLIB_API size_t ZBUFF_compressInitDictionary(ZBUFF_CCtx* zbc, const void* dict, size_t dictSize, int compressionLevel)
+ZSTDLIB_API size_t ZBUFF_0_5_X_compressInitDictionary(ZBUFF_0_5_X_CCtx* zbc, const void* dict, size_t dictSize, int compressionLevel)
 {
-    return ZBUFF_compressInit_advanced(zbc, dict, dictSize, ZSTD_getParams(compressionLevel, 0));
+    return ZBUFF_0_5_X_compressInit_advanced(zbc, dict, dictSize, ZSTD_0_5_X_getParams(compressionLevel, 0));
 }
 
 
 /* *** Compression *** */
 
-static size_t ZBUFF_limitCopy(void* dst, size_t maxDstSize, const void* src, size_t srcSize)
+static size_t ZBUFF_0_5_X_limitCopy(void* dst, size_t maxDstSize, const void* src, size_t srcSize)
 {
     size_t length = MIN(maxDstSize, srcSize);
     memcpy(dst, src, length);
     return length;
 }
 
-static size_t ZBUFF_compressContinue_generic(ZBUFF_CCtx* zbc,
+static size_t ZBUFF_0_5_X_compressContinue_generic(ZBUFF_0_5_X_CCtx* zbc,
                               void* dst, size_t* maxDstSizePtr,
                         const void* src, size_t* srcSizePtr,
                               int flush)   /* aggregate : wait for full block before compressing */
@@ -195,13 +195,13 @@ static size_t ZBUFF_compressContinue_generic(ZBUFF_CCtx* zbc,
     while (notDone) {
         switch(zbc->stage)
         {
-        case ZBUFFcs_init: return ERROR(init_missing);   /* call ZBUFF_compressInit() first ! */
+        case ZBUFFcs_init: return ERROR(init_missing);   /* call ZBUFF_0_5_X_compressInit() first ! */
 
         case ZBUFFcs_load:
             /* complete inBuffer */
             {
                 size_t toLoad = zbc->inBuffTarget - zbc->inBuffPos;
-                size_t loaded = ZBUFF_limitCopy(zbc->inBuff + zbc->inBuffPos, toLoad, ip, iend-ip);
+                size_t loaded = ZBUFF_0_5_X_limitCopy(zbc->inBuff + zbc->inBuffPos, toLoad, ip, iend-ip);
                 zbc->inBuffPos += loaded;
                 ip += loaded;
                 if ( (zbc->inBuffPos==zbc->inToCompress) || (!flush && (toLoad != loaded)) ) {
@@ -213,12 +213,12 @@ static size_t ZBUFF_compressContinue_generic(ZBUFF_CCtx* zbc,
                 size_t cSize;
                 size_t iSize = zbc->inBuffPos - zbc->inToCompress;
                 size_t oSize = oend-op;
-                if (oSize >= ZSTD_compressBound(iSize))
+                if (oSize >= ZSTD_0_5_X_compressBound(iSize))
                     cDst = op;   /* compress directly into output buffer (avoid flush stage) */
                 else
                     cDst = zbc->outBuff, oSize = zbc->outBuffSize;
-                cSize = ZSTD_compressContinue(zbc->zc, cDst, oSize, zbc->inBuff + zbc->inToCompress, iSize);
-                if (ZSTD_isError(cSize)) return cSize;
+                cSize = ZSTD_0_5_X_compressContinue(zbc->zc, cDst, oSize, zbc->inBuff + zbc->inToCompress, iSize);
+                if (ZSTD_0_5_X_isError(cSize)) return cSize;
                 /* prepare next block */
                 zbc->inBuffTarget = zbc->inBuffPos + zbc->blockSize;
                 if (zbc->inBuffTarget > zbc->inBuffSize)
@@ -235,7 +235,7 @@ static size_t ZBUFF_compressContinue_generic(ZBUFF_CCtx* zbc,
             /* flush into dst */
             {
                 size_t toFlush = zbc->outBuffContentSize - zbc->outBuffFlushedSize;
-                size_t flushed = ZBUFF_limitCopy(op, oend-op, zbc->outBuff + zbc->outBuffFlushedSize, toFlush);
+                size_t flushed = ZBUFF_0_5_X_limitCopy(op, oend-op, zbc->outBuff + zbc->outBuffFlushedSize, toFlush);
                 op += flushed;
                 zbc->outBuffFlushedSize += flushed;
                 if (toFlush!=flushed) { notDone = 0; break; } /* not enough space within dst to store compressed block : stop there */
@@ -258,39 +258,39 @@ static size_t ZBUFF_compressContinue_generic(ZBUFF_CCtx* zbc,
     }
 }
 
-size_t ZBUFF_compressContinue(ZBUFF_CCtx* zbc,
+size_t ZBUFF_0_5_X_compressContinue(ZBUFF_0_5_X_CCtx* zbc,
                               void* dst, size_t* maxDstSizePtr,
                         const void* src, size_t* srcSizePtr)
 {
-    return ZBUFF_compressContinue_generic(zbc, dst, maxDstSizePtr, src, srcSizePtr, 0);
+    return ZBUFF_0_5_X_compressContinue_generic(zbc, dst, maxDstSizePtr, src, srcSizePtr, 0);
 }
 
 
 
 /* *** Finalize *** */
 
-size_t ZBUFF_compressFlush(ZBUFF_CCtx* zbc, void* dst, size_t* maxDstSizePtr)
+size_t ZBUFF_0_5_X_compressFlush(ZBUFF_0_5_X_CCtx* zbc, void* dst, size_t* maxDstSizePtr)
 {
     size_t srcSize = 0;
-    ZBUFF_compressContinue_generic(zbc, dst, maxDstSizePtr, &srcSize, &srcSize, 1);  /* use a valid src address instead of NULL, as some sanitizer don't like it */
+    ZBUFF_0_5_X_compressContinue_generic(zbc, dst, maxDstSizePtr, &srcSize, &srcSize, 1);  /* use a valid src address instead of NULL, as some sanitizer don't like it */
     return zbc->outBuffContentSize - zbc->outBuffFlushedSize;
 }
 
 
-size_t ZBUFF_compressEnd(ZBUFF_CCtx* zbc, void* dst, size_t* maxDstSizePtr)
+size_t ZBUFF_0_5_X_compressEnd(ZBUFF_0_5_X_CCtx* zbc, void* dst, size_t* maxDstSizePtr)
 {
     BYTE* const ostart = (BYTE*)dst;
     BYTE* op = ostart;
     BYTE* const oend = ostart + *maxDstSizePtr;
     size_t outSize = *maxDstSizePtr;
     size_t epilogueSize, remaining;
-    ZBUFF_compressFlush(zbc, dst, &outSize);    /* flush any remaining inBuff */
+    ZBUFF_0_5_X_compressFlush(zbc, dst, &outSize);    /* flush any remaining inBuff */
     op += outSize;
-    epilogueSize = ZSTD_compressEnd(zbc->zc, zbc->outBuff + zbc->outBuffContentSize, zbc->outBuffSize - zbc->outBuffContentSize);   /* epilogue into outBuff */
+    epilogueSize = ZSTD_0_5_X_compressEnd(zbc->zc, zbc->outBuff + zbc->outBuffContentSize, zbc->outBuffSize - zbc->outBuffContentSize);   /* epilogue into outBuff */
     zbc->outBuffContentSize += epilogueSize;
     outSize = oend-op;
     zbc->stage = ZBUFFcs_flush;
-    remaining = ZBUFF_compressFlush(zbc, op, &outSize);   /* attempt to flush epilogue into dst */
+    remaining = ZBUFF_0_5_X_compressFlush(zbc, op, &outSize);   /* attempt to flush epilogue into dst */
     op += outSize;
     if (!remaining) zbc->stage = ZBUFFcs_init;  /* close only if nothing left to flush */
     *maxDstSizePtr = op-ostart;                 /* tells how many bytes were written */
@@ -302,34 +302,34 @@ size_t ZBUFF_compressEnd(ZBUFF_CCtx* zbc, void* dst, size_t* maxDstSizePtr)
 /** ************************************************
 *  Streaming decompression
 *
-*  A ZBUFF_DCtx object is required to track streaming operation.
-*  Use ZBUFF_createDCtx() and ZBUFF_freeDCtx() to create/release resources.
-*  Use ZBUFF_decompressInit() to start a new decompression operation.
-*  ZBUFF_DCtx objects can be reused multiple times.
+*  A ZBUFF_0_5_X_DCtx object is required to track streaming operation.
+*  Use ZBUFF_0_5_X_createDCtx() and ZBUFF_0_5_X_freeDCtx() to create/release resources.
+*  Use ZBUFF_0_5_X_decompressInit() to start a new decompression operation.
+*  ZBUFF_0_5_X_DCtx objects can be reused multiple times.
 *
-*  Use ZBUFF_decompressContinue() repetitively to consume your input.
+*  Use ZBUFF_0_5_X_decompressContinue() repetitively to consume your input.
 *  *srcSizePtr and *maxDstSizePtr can be any size.
 *  The function will report how many bytes were read or written by modifying *srcSizePtr and *maxDstSizePtr.
 *  Note that it may not consume the entire input, in which case it's up to the caller to call again the function with remaining input.
 *  The content of dst will be overwritten (up to *maxDstSizePtr) at each function call, so save its content if it matters or change dst .
 *  @return : a hint to preferred nb of bytes to use as input for next function call (it's only a hint, to improve latency)
 *            or 0 when a frame is completely decoded
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
 *  Hint : recommended buffer sizes (not compulsory)
 *  output : 128 KB block size is the internal unit, it ensures it's always possible to write a full block when it's decoded.
-*  input : just follow indications from ZBUFF_decompressContinue() to minimize latency. It should always be <= 128 KB + 3 .
+*  input : just follow indications from ZBUFF_0_5_X_decompressContinue() to minimize latency. It should always be <= 128 KB + 3 .
 * **************************************************/
 
 typedef enum { ZBUFFds_init, ZBUFFds_readHeader, ZBUFFds_loadHeader, ZBUFFds_decodeHeader,
-               ZBUFFds_read, ZBUFFds_load, ZBUFFds_flush } ZBUFF_dStage;
+               ZBUFFds_read, ZBUFFds_load, ZBUFFds_flush } ZBUFF_0_5_X_dStage;
 
 /* *** Resource management *** */
 
-#define ZSTD_frameHeaderSize_max 5   /* too magical, should come from reference */
-struct ZBUFF_DCtx_s {
-    ZSTD_DCtx* zc;
-    ZSTD_parameters params;
+#define ZSTD_0_5_X_frameHeaderSize_max 5   /* too magical, should come from reference */
+struct ZBUFF_0_5_X_DCtx_s {
+    ZSTD_0_5_X_DCtx* zc;
+    ZSTD_0_5_X_parameters params;
     char* inBuff;
     size_t inBuffSize;
     size_t inPos;
@@ -338,25 +338,25 @@ struct ZBUFF_DCtx_s {
     size_t outStart;
     size_t outEnd;
     size_t hPos;
-    ZBUFF_dStage stage;
-    unsigned char headerBuffer[ZSTD_frameHeaderSize_max];
-};   /* typedef'd to ZBUFF_DCtx within "zstd_buffered.h" */
+    ZBUFF_0_5_X_dStage stage;
+    unsigned char headerBuffer[ZSTD_0_5_X_frameHeaderSize_max];
+};   /* typedef'd to ZBUFF_0_5_X_DCtx within "zstd_buffered.h" */
 
 
-ZBUFF_DCtx* ZBUFF_createDCtx(void)
+ZBUFF_0_5_X_DCtx* ZBUFF_0_5_X_createDCtx(void)
 {
-    ZBUFF_DCtx* zbc = (ZBUFF_DCtx*)malloc(sizeof(ZBUFF_DCtx));
+    ZBUFF_0_5_X_DCtx* zbc = (ZBUFF_0_5_X_DCtx*)malloc(sizeof(ZBUFF_0_5_X_DCtx));
     if (zbc==NULL) return NULL;
     memset(zbc, 0, sizeof(*zbc));
-    zbc->zc = ZSTD_createDCtx();
+    zbc->zc = ZSTD_0_5_X_createDCtx();
     zbc->stage = ZBUFFds_init;
     return zbc;
 }
 
-size_t ZBUFF_freeDCtx(ZBUFF_DCtx* zbc)
+size_t ZBUFF_0_5_X_freeDCtx(ZBUFF_0_5_X_DCtx* zbc)
 {
     if (zbc==NULL) return 0;   /* support free on null */
-    ZSTD_freeDCtx(zbc->zc);
+    ZSTD_0_5_X_freeDCtx(zbc->zc);
     free(zbc->inBuff);
     free(zbc->outBuff);
     free(zbc);
@@ -366,22 +366,22 @@ size_t ZBUFF_freeDCtx(ZBUFF_DCtx* zbc)
 
 /* *** Initialization *** */
 
-size_t ZBUFF_decompressInitDictionary(ZBUFF_DCtx* zbc, const void* dict, size_t dictSize)
+size_t ZBUFF_0_5_X_decompressInitDictionary(ZBUFF_0_5_X_DCtx* zbc, const void* dict, size_t dictSize)
 {
     zbc->stage = ZBUFFds_readHeader;
     zbc->hPos = zbc->inPos = zbc->outStart = zbc->outEnd = 0;
-    return ZSTD_decompressBegin_usingDict(zbc->zc, dict, dictSize);
+    return ZSTD_0_5_X_decompressBegin_usingDict(zbc->zc, dict, dictSize);
 }
 
-size_t ZBUFF_decompressInit(ZBUFF_DCtx* zbc)
+size_t ZBUFF_0_5_X_decompressInit(ZBUFF_0_5_X_DCtx* zbc)
 {
-    return ZBUFF_decompressInitDictionary(zbc, NULL, 0);
+    return ZBUFF_0_5_X_decompressInitDictionary(zbc, NULL, 0);
 }
 
 
 /* *** Decompression *** */
 
-size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePtr, const void* src, size_t* srcSizePtr)
+size_t ZBUFF_0_5_X_decompressContinue(ZBUFF_0_5_X_DCtx* zbc, void* dst, size_t* maxDstSizePtr, const void* src, size_t* srcSizePtr)
 {
     const char* const istart = (const char*)src;
     const char* ip = istart;
@@ -400,8 +400,8 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
         case ZBUFFds_readHeader :
             /* read header from src */
             {
-                size_t headerSize = ZSTD_getFrameParams(&(zbc->params), src, *srcSizePtr);
-                if (ZSTD_isError(headerSize)) return headerSize;
+                size_t headerSize = ZSTD_0_5_X_getFrameParams(&(zbc->params), src, *srcSizePtr);
+                if (ZSTD_0_5_X_isError(headerSize)) return headerSize;
                 if (headerSize) {
                     /* not enough input to decode header : tell how many bytes would be necessary */
                     memcpy(zbc->headerBuffer+zbc->hPos, src, *srcSizePtr);
@@ -417,13 +417,13 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
         case ZBUFFds_loadHeader:
             /* complete header from src */
             {
-                size_t headerSize = ZBUFF_limitCopy(
-                    zbc->headerBuffer + zbc->hPos, ZSTD_frameHeaderSize_max - zbc->hPos,
+                size_t headerSize = ZBUFF_0_5_X_limitCopy(
+                    zbc->headerBuffer + zbc->hPos, ZSTD_0_5_X_frameHeaderSize_max - zbc->hPos,
                     src, *srcSizePtr);
                 zbc->hPos += headerSize;
                 ip += headerSize;
-                headerSize = ZSTD_getFrameParams(&(zbc->params), zbc->headerBuffer, zbc->hPos);
-                if (ZSTD_isError(headerSize)) return headerSize;
+                headerSize = ZSTD_0_5_X_getFrameParams(&(zbc->params), zbc->headerBuffer, zbc->hPos);
+                if (ZSTD_0_5_X_isError(headerSize)) return headerSize;
                 if (headerSize) {
                     /* not enough input to decode header : tell how many bytes would be necessary */
                     *maxDstSizePtr = 0;
@@ -461,7 +461,7 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
 
         case ZBUFFds_read:
             {
-                size_t neededInSize = ZSTD_nextSrcSizeToDecompress(zbc->zc);
+                size_t neededInSize = ZSTD_0_5_X_nextSrcSizeToDecompress(zbc->zc);
                 if (neededInSize==0) {  /* end of frame */
                     zbc->stage = ZBUFFds_init;
                     notDone = 0;
@@ -469,10 +469,10 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
                 }
                 if ((size_t)(iend-ip) >= neededInSize) {
                     /* directly decode from src */
-                    size_t decodedSize = ZSTD_decompressContinue(zbc->zc,
+                    size_t decodedSize = ZSTD_0_5_X_decompressContinue(zbc->zc,
                         zbc->outBuff + zbc->outStart, zbc->outBuffSize - zbc->outStart,
                         ip, neededInSize);
-                    if (ZSTD_isError(decodedSize)) return decodedSize;
+                    if (ZSTD_0_5_X_isError(decodedSize)) return decodedSize;
                     ip += neededInSize;
                     if (!decodedSize) break;   /* this was just a header */
                     zbc->outEnd = zbc->outStart +  decodedSize;
@@ -485,19 +485,19 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
 
         case ZBUFFds_load:
             {
-                size_t neededInSize = ZSTD_nextSrcSizeToDecompress(zbc->zc);
+                size_t neededInSize = ZSTD_0_5_X_nextSrcSizeToDecompress(zbc->zc);
                 size_t toLoad = neededInSize - zbc->inPos;   /* should always be <= remaining space within inBuff */
                 size_t loadedSize;
                 if (toLoad > zbc->inBuffSize - zbc->inPos) return ERROR(corruption_detected);   /* should never happen */
-                loadedSize = ZBUFF_limitCopy(zbc->inBuff + zbc->inPos, toLoad, ip, iend-ip);
+                loadedSize = ZBUFF_0_5_X_limitCopy(zbc->inBuff + zbc->inPos, toLoad, ip, iend-ip);
                 ip += loadedSize;
                 zbc->inPos += loadedSize;
                 if (loadedSize < toLoad) { notDone = 0; break; }   /* not enough input, wait for more */
                 {
-                    size_t decodedSize = ZSTD_decompressContinue(zbc->zc,
+                    size_t decodedSize = ZSTD_0_5_X_decompressContinue(zbc->zc,
                         zbc->outBuff + zbc->outStart, zbc->outBuffSize - zbc->outStart,
                         zbc->inBuff, neededInSize);
-                    if (ZSTD_isError(decodedSize)) return decodedSize;
+                    if (ZSTD_0_5_X_isError(decodedSize)) return decodedSize;
                     zbc->inPos = 0;   /* input is consumed */
                     if (!decodedSize) { zbc->stage = ZBUFFds_read; break; }   /* this was just a header */
                     zbc->outEnd = zbc->outStart +  decodedSize;
@@ -507,7 +507,7 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
         case ZBUFFds_flush:
             {
                 size_t toFlushSize = zbc->outEnd - zbc->outStart;
-                size_t flushedSize = ZBUFF_limitCopy(op, oend-op, zbc->outBuff + zbc->outStart, toFlushSize);
+                size_t flushedSize = ZBUFF_0_5_X_limitCopy(op, oend-op, zbc->outBuff + zbc->outStart, toFlushSize);
                 op += flushedSize;
                 zbc->outStart += flushedSize;
                 if (flushedSize == toFlushSize) {
@@ -527,8 +527,8 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
     *maxDstSizePtr = op-ostart;
 
     {
-        size_t nextSrcSizeHint = ZSTD_nextSrcSizeToDecompress(zbc->zc);
-        if (nextSrcSizeHint > ZBUFF_blockHeaderSize) nextSrcSizeHint+= ZBUFF_blockHeaderSize;   /* get next block header too */
+        size_t nextSrcSizeHint = ZSTD_0_5_X_nextSrcSizeToDecompress(zbc->zc);
+        if (nextSrcSizeHint > ZBUFF_0_5_X_blockHeaderSize) nextSrcSizeHint+= ZBUFF_0_5_X_blockHeaderSize;   /* get next block header too */
         nextSrcSizeHint -= zbc->inPos;   /* already loaded*/
         return nextSrcSizeHint;
     }
@@ -539,10 +539,10 @@ size_t ZBUFF_decompressContinue(ZBUFF_DCtx* zbc, void* dst, size_t* maxDstSizePt
 /* *************************************
 *  Tool functions
 ***************************************/
-unsigned ZBUFF_isError(size_t errorCode) { return ERR_isError(errorCode); }
-const char* ZBUFF_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
+unsigned ZBUFF_0_5_X_isError(size_t errorCode) { return ERR_isError(errorCode); }
+const char* ZBUFF_0_5_X_getErrorName(size_t errorCode) { return ERR_getErrorName(errorCode); }
 
-size_t ZBUFF_recommendedCInSize(void)  { return BLOCKSIZE; }
-size_t ZBUFF_recommendedCOutSize(void) { return ZSTD_compressBound(BLOCKSIZE) + ZBUFF_blockHeaderSize + ZBUFF_endFrameSize; }
-size_t ZBUFF_recommendedDInSize(void)  { return BLOCKSIZE + ZBUFF_blockHeaderSize /* block header size*/ ; }
-size_t ZBUFF_recommendedDOutSize(void) { return BLOCKSIZE; }
+size_t ZBUFF_0_5_X_recommendedCInSize(void)  { return BLOCKSIZE; }
+size_t ZBUFF_0_5_X_recommendedCOutSize(void) { return ZSTD_0_5_X_compressBound(BLOCKSIZE) + ZBUFF_0_5_X_blockHeaderSize + ZBUFF_0_5_X_endFrameSize; }
+size_t ZBUFF_0_5_X_recommendedDInSize(void)  { return BLOCKSIZE + ZBUFF_0_5_X_blockHeaderSize /* block header size*/ ; }
+size_t ZBUFF_0_5_X_recommendedDOutSize(void) { return BLOCKSIZE; }

--- a/zstd_buffered.h
+++ b/zstd_buffered.h
@@ -29,8 +29,8 @@
     - zstd source repository : https://github.com/Cyan4973/zstd
     - ztsd public forum : https://groups.google.com/forum/#!forum/lz4c
 */
-#ifndef ZSTD_BUFFERED_H
-#define ZSTD_BUFFERED_H
+#ifndef ZSTD_0_5_X_BUFFERED_H
+#define ZSTD_0_5_X_BUFFERED_H
 
 /* The objects defined into this file should be considered experimental.
  * They are not labelled stable, as their prototype may change in the future.
@@ -51,10 +51,10 @@ extern "C" {
 *  Compiler specifics
 *****************************************************************/
 /*!
-*  ZSTD_DLL_EXPORT :
+*  ZSTD_0_5_X_DLL_EXPORT :
 *  Enable exporting of functions when building a Windows DLL
 */
-#if defined(_WIN32) && defined(ZSTD_DLL_EXPORT) && (ZSTD_DLL_EXPORT==1)
+#if defined(_WIN32) && defined(ZSTD_0_5_X_DLL_EXPORT) && (ZSTD_0_5_X_DLL_EXPORT==1)
 #  define ZSTDLIB_API __declspec(dllexport)
 #else
 #  define ZSTDLIB_API
@@ -64,107 +64,107 @@ extern "C" {
 /* *************************************
 *  Streaming functions
 ***************************************/
-typedef struct ZBUFF_CCtx_s ZBUFF_CCtx;
-ZSTDLIB_API ZBUFF_CCtx* ZBUFF_createCCtx(void);
-ZSTDLIB_API size_t      ZBUFF_freeCCtx(ZBUFF_CCtx* cctx);
+typedef struct ZBUFF_0_5_X_CCtx_s ZBUFF_0_5_X_CCtx;
+ZSTDLIB_API ZBUFF_0_5_X_CCtx* ZBUFF_0_5_X_createCCtx(void);
+ZSTDLIB_API size_t      ZBUFF_0_5_X_freeCCtx(ZBUFF_0_5_X_CCtx* cctx);
 
-ZSTDLIB_API size_t ZBUFF_compressInit(ZBUFF_CCtx* cctx, int compressionLevel);
-ZSTDLIB_API size_t ZBUFF_compressInitDictionary(ZBUFF_CCtx* cctx, const void* dict, size_t dictSize, int compressionLevel);
+ZSTDLIB_API size_t ZBUFF_0_5_X_compressInit(ZBUFF_0_5_X_CCtx* cctx, int compressionLevel);
+ZSTDLIB_API size_t ZBUFF_0_5_X_compressInitDictionary(ZBUFF_0_5_X_CCtx* cctx, const void* dict, size_t dictSize, int compressionLevel);
 
-ZSTDLIB_API size_t ZBUFF_compressContinue(ZBUFF_CCtx* cctx, void* dst, size_t* dstCapacityPtr, const void* src, size_t* srcSizePtr);
-ZSTDLIB_API size_t ZBUFF_compressFlush(ZBUFF_CCtx* cctx, void* dst, size_t* dstCapacityPtr);
-ZSTDLIB_API size_t ZBUFF_compressEnd(ZBUFF_CCtx* cctx, void* dst, size_t* dstCapacityPtr);
+ZSTDLIB_API size_t ZBUFF_0_5_X_compressContinue(ZBUFF_0_5_X_CCtx* cctx, void* dst, size_t* dstCapacityPtr, const void* src, size_t* srcSizePtr);
+ZSTDLIB_API size_t ZBUFF_0_5_X_compressFlush(ZBUFF_0_5_X_CCtx* cctx, void* dst, size_t* dstCapacityPtr);
+ZSTDLIB_API size_t ZBUFF_0_5_X_compressEnd(ZBUFF_0_5_X_CCtx* cctx, void* dst, size_t* dstCapacityPtr);
 
 /** ************************************************
 *  Streaming compression
 *
-*  A ZBUFF_CCtx object is required to track streaming operation.
-*  Use ZBUFF_createCCtx() and ZBUFF_freeCCtx() to create/release resources.
-*  ZBUFF_CCtx objects can be reused multiple times.
+*  A ZBUFF_0_5_X_CCtx object is required to track streaming operation.
+*  Use ZBUFF_0_5_X_createCCtx() and ZBUFF_0_5_X_freeCCtx() to create/release resources.
+*  ZBUFF_0_5_X_CCtx objects can be reused multiple times.
 *
 *  Start by initializing ZBUF_CCtx.
-*  Use ZBUFF_compressInit() to start a new compression operation.
-*  Use ZBUFF_compressInitDictionary() for a compression which requires a dictionary.
+*  Use ZBUFF_0_5_X_compressInit() to start a new compression operation.
+*  Use ZBUFF_0_5_X_compressInitDictionary() for a compression which requires a dictionary.
 *
-*  Use ZBUFF_compressContinue() repetitively to consume input stream.
+*  Use ZBUFF_0_5_X_compressContinue() repetitively to consume input stream.
 *  *srcSizePtr and *dstCapacityPtr can be any size.
 *  The function will report how many bytes were read or written within *srcSizePtr and *dstCapacityPtr.
 *  Note that it may not consume the entire input, in which case it's up to the caller to present again remaining data.
 *  The content of @dst will be overwritten (up to *dstCapacityPtr) at each call, so save its content if it matters or change @dst .
 *  @return : a hint to preferred nb of bytes to use as input for next function call (it's just a hint, to improve latency)
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
-*  At any moment, it's possible to flush whatever data remains within buffer, using ZBUFF_compressFlush().
+*  At any moment, it's possible to flush whatever data remains within buffer, using ZBUFF_0_5_X_compressFlush().
 *  The nb of bytes written into @dst will be reported into *dstCapacityPtr.
 *  Note that the function cannot output more than *dstCapacityPtr,
 *  therefore, some content might still be left into internal buffer if *dstCapacityPtr is too small.
 *  @return : nb of bytes still present into internal buffer (0 if it's empty)
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
-*  ZBUFF_compressEnd() instructs to finish a frame.
+*  ZBUFF_0_5_X_compressEnd() instructs to finish a frame.
 *  It will perform a flush and write frame epilogue.
 *  The epilogue is required for decoders to consider a frame completed.
-*  Similar to ZBUFF_compressFlush(), it may not be able to output the entire internal buffer content if *dstCapacityPtr is too small.
-*  In which case, call again ZBUFF_compressFlush() to complete the flush.
+*  Similar to ZBUFF_0_5_X_compressFlush(), it may not be able to output the entire internal buffer content if *dstCapacityPtr is too small.
+*  In which case, call again ZBUFF_0_5_X_compressFlush() to complete the flush.
 *  @return : nb of bytes still present into internal buffer (0 if it's empty)
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
-*  Hint : recommended buffer sizes (not compulsory) : ZBUFF_recommendedCInSize / ZBUFF_recommendedCOutSize
-*  input : ZBUFF_recommendedCInSize==128 KB block size is the internal unit, it improves latency to use this value (skipped buffering).
-*  output : ZBUFF_recommendedCOutSize==ZSTD_compressBound(128 KB) + 3 + 3 : ensures it's always possible to write/flush/end a full block. Skip some buffering.
+*  Hint : recommended buffer sizes (not compulsory) : ZBUFF_0_5_X_recommendedCInSize / ZBUFF_0_5_X_recommendedCOutSize
+*  input : ZBUFF_0_5_X_recommendedCInSize==128 KB block size is the internal unit, it improves latency to use this value (skipped buffering).
+*  output : ZBUFF_0_5_X_recommendedCOutSize==ZSTD_0_5_X_compressBound(128 KB) + 3 + 3 : ensures it's always possible to write/flush/end a full block. Skip some buffering.
 *  By using both, it ensures that input will be entirely consumed, and output will always contain the result, reducing intermediate buffering.
 * **************************************************/
 
 
-typedef struct ZBUFF_DCtx_s ZBUFF_DCtx;
-ZSTDLIB_API ZBUFF_DCtx* ZBUFF_createDCtx(void);
-ZSTDLIB_API size_t      ZBUFF_freeDCtx(ZBUFF_DCtx* dctx);
+typedef struct ZBUFF_0_5_X_DCtx_s ZBUFF_0_5_X_DCtx;
+ZSTDLIB_API ZBUFF_0_5_X_DCtx* ZBUFF_0_5_X_createDCtx(void);
+ZSTDLIB_API size_t      ZBUFF_0_5_X_freeDCtx(ZBUFF_0_5_X_DCtx* dctx);
 
-ZSTDLIB_API size_t ZBUFF_decompressInit(ZBUFF_DCtx* dctx);
-ZSTDLIB_API size_t ZBUFF_decompressInitDictionary(ZBUFF_DCtx* dctx, const void* dict, size_t dictSize);
+ZSTDLIB_API size_t ZBUFF_0_5_X_decompressInit(ZBUFF_0_5_X_DCtx* dctx);
+ZSTDLIB_API size_t ZBUFF_0_5_X_decompressInitDictionary(ZBUFF_0_5_X_DCtx* dctx, const void* dict, size_t dictSize);
 
-ZSTDLIB_API size_t ZBUFF_decompressContinue(ZBUFF_DCtx* dctx, void* dst, size_t* dstCapacityPtr, const void* src, size_t* srcSizePtr);
+ZSTDLIB_API size_t ZBUFF_0_5_X_decompressContinue(ZBUFF_0_5_X_DCtx* dctx, void* dst, size_t* dstCapacityPtr, const void* src, size_t* srcSizePtr);
 
 /** ************************************************
 *  Streaming decompression
 *
-*  A ZBUFF_DCtx object is required to track streaming operation.
-*  Use ZBUFF_createDCtx() and ZBUFF_freeDCtx() to create/release resources.
-*  Use ZBUFF_decompressInit() to start a new decompression operation,
-*   or ZBUFF_decompressInitDictionary() if decompression requires a dictionary.
-*  Note that ZBUFF_DCtx objects can be reused multiple times.
+*  A ZBUFF_0_5_X_DCtx object is required to track streaming operation.
+*  Use ZBUFF_0_5_X_createDCtx() and ZBUFF_0_5_X_freeDCtx() to create/release resources.
+*  Use ZBUFF_0_5_X_decompressInit() to start a new decompression operation,
+*   or ZBUFF_0_5_X_decompressInitDictionary() if decompression requires a dictionary.
+*  Note that ZBUFF_0_5_X_DCtx objects can be reused multiple times.
 *
-*  Use ZBUFF_decompressContinue() repetitively to consume your input.
+*  Use ZBUFF_0_5_X_decompressContinue() repetitively to consume your input.
 *  *srcSizePtr and *dstCapacityPtr can be any size.
 *  The function will report how many bytes were read or written by modifying *srcSizePtr and *dstCapacityPtr.
 *  Note that it may not consume the entire input, in which case it's up to the caller to present remaining input again.
 *  The content of @dst will be overwritten (up to *dstCapacityPtr) at each function call, so save its content if it matters or change @dst.
 *  @return : a hint to preferred nb of bytes to use as input for next function call (it's only a hint, to help latency)
 *            or 0 when a frame is completely decoded
-*            or an error code, which can be tested using ZBUFF_isError().
+*            or an error code, which can be tested using ZBUFF_0_5_X_isError().
 *
-*  Hint : recommended buffer sizes (not compulsory) : ZBUFF_recommendedDInSize / ZBUFF_recommendedDOutSize
-*  output : ZBUFF_recommendedDOutSize==128 KB block size is the internal unit, it ensures it's always possible to write a full block when it's decoded.
-*  input : ZBUFF_recommendedDInSize==128Kb+3; just follow indications from ZBUFF_decompressContinue() to minimize latency. It should always be <= 128 KB + 3 .
+*  Hint : recommended buffer sizes (not compulsory) : ZBUFF_0_5_X_recommendedDInSize / ZBUFF_0_5_X_recommendedDOutSize
+*  output : ZBUFF_0_5_X_recommendedDOutSize==128 KB block size is the internal unit, it ensures it's always possible to write a full block when it's decoded.
+*  input : ZBUFF_0_5_X_recommendedDInSize==128Kb+3; just follow indications from ZBUFF_0_5_X_decompressContinue() to minimize latency. It should always be <= 128 KB + 3 .
 * **************************************************/
 
 
 /* *************************************
 *  Tool functions
 ***************************************/
-ZSTDLIB_API unsigned ZBUFF_isError(size_t errorCode);
-ZSTDLIB_API const char* ZBUFF_getErrorName(size_t errorCode);
+ZSTDLIB_API unsigned ZBUFF_0_5_X_isError(size_t errorCode);
+ZSTDLIB_API const char* ZBUFF_0_5_X_getErrorName(size_t errorCode);
 
 /** The below functions provide recommended buffer sizes for Compression or Decompression operations.
 *   These sizes are just hints, and tend to offer better latency */
-ZSTDLIB_API size_t ZBUFF_recommendedCInSize(void);
-ZSTDLIB_API size_t ZBUFF_recommendedCOutSize(void);
-ZSTDLIB_API size_t ZBUFF_recommendedDInSize(void);
-ZSTDLIB_API size_t ZBUFF_recommendedDOutSize(void);
+ZSTDLIB_API size_t ZBUFF_0_5_X_recommendedCInSize(void);
+ZSTDLIB_API size_t ZBUFF_0_5_X_recommendedCOutSize(void);
+ZSTDLIB_API size_t ZBUFF_0_5_X_recommendedDInSize(void);
+ZSTDLIB_API size_t ZBUFF_0_5_X_recommendedDOutSize(void);
 
 
 #if defined (__cplusplus)
 }
 #endif
 
-#endif  /* ZSTD_BUFFERED_H */
+#endif  /* ZSTD_0_5_X_BUFFERED_H */

--- a/zstd_buffered_static.h
+++ b/zstd_buffered_static.h
@@ -30,8 +30,8 @@
     - zstd source repository : https://github.com/Cyan4973/zstd
     - ztsd public forum : https://groups.google.com/forum/#!forum/lz4c
 */
-#ifndef ZSTD_BUFFERED_STATIC_H
-#define ZSTD_BUFFERED_STATIC_H
+#ifndef ZSTD_0_5_X_BUFFERED_STATIC_H
+#define ZSTD_0_5_X_BUFFERED_STATIC_H
 
 /* The objects defined into this file should be considered experimental.
  * They are not labelled stable, as their prototype may change in the future.
@@ -45,18 +45,18 @@ extern "C" {
 /* *************************************
 *  Includes
 ***************************************/
-#include "zstd_static.h"     /* ZSTD_parameters */
+#include "zstd_static.h"     /* ZSTD_0_5_X_parameters */
 #include "zstd_buffered.h"
 
 
 /* *************************************
 *  Advanced Streaming functions
 ***************************************/
-ZSTDLIB_API size_t ZBUFF_compressInit_advanced(ZBUFF_CCtx* cctx, const void* dict, size_t dictSize, ZSTD_parameters params);
+ZSTDLIB_API size_t ZBUFF_0_5_X_compressInit_advanced(ZBUFF_0_5_X_CCtx* cctx, const void* dict, size_t dictSize, ZSTD_0_5_X_parameters params);
 
 
 #if defined (__cplusplus)
 }
 #endif
 
-#endif  /* ZSTD_BUFFERED_STATIC_H */
+#endif  /* ZSTD_0_5_X_BUFFERED_STATIC_H */

--- a/zstd_decompress.c
+++ b/zstd_decompress.c
@@ -34,19 +34,19 @@
 *****************************************************************/
 /*!
  * HEAPMODE :
- * Select how default decompression function ZSTD_decompress() will allocate memory,
+ * Select how default decompression function ZSTD_0_5_X_decompress() will allocate memory,
  * in memory stack (0), or in memory heap (1, requires malloc())
  */
-#ifndef ZSTD_HEAPMODE
-#  define ZSTD_HEAPMODE 0
+#ifndef ZSTD_0_5_X_HEAPMODE
+#  define ZSTD_0_5_X_HEAPMODE 0
 #endif
 
 /*!
 *  LEGACY_SUPPORT :
-*  if set to 1, ZSTD_decompress() can decode older formats (v0.1+)
+*  if set to 1, ZSTD_0_5_X_decompress() can decode older formats (v0.1+)
 */
-#ifndef ZSTD_LEGACY_SUPPORT
-#  define ZSTD_LEGACY_SUPPORT 0
+#ifndef ZSTD_0_5_X_LEGACY_SUPPORT
+#  define ZSTD_0_5_X_LEGACY_SUPPORT 0
 #endif
 
 
@@ -61,7 +61,7 @@
 #include "fse_static.h"
 #include "huff0_static.h"
 
-#if defined(ZSTD_LEGACY_SUPPORT) && (ZSTD_LEGACY_SUPPORT==1)
+#if defined(ZSTD_0_5_X_LEGACY_SUPPORT) && (ZSTD_0_5_X_LEGACY_SUPPORT==1)
 #  include "zstd_legacy.h"
 #endif
 
@@ -97,61 +97,61 @@ typedef struct
 /* *******************************************************
 *  Memory operations
 **********************************************************/
-static void ZSTD_copy4(void* dst, const void* src) { memcpy(dst, src, 4); }
+static void ZSTD_0_5_X_copy4(void* dst, const void* src) { memcpy(dst, src, 4); }
 
 
 /* *************************************
 *  Error Management
 ***************************************/
-unsigned ZSTD_versionNumber (void) { return ZSTD_VERSION_NUMBER; }
+unsigned ZSTD_0_5_X_versionNumber (void) { return ZSTD_0_5_X_VERSION_NUMBER; }
 
-/*! ZSTD_isError() :
+/*! ZSTD_0_5_X_isError() :
 *   tells if a return value is an error code */
-unsigned ZSTD_isError(size_t code) { return ERR_isError(code); }
+unsigned ZSTD_0_5_X_isError(size_t code) { return ERR_isError(code); }
 
-/*! ZSTD_getError() :
-*   convert a `size_t` function result into a proper ZSTD_errorCode enum */
-ZSTD_ErrorCode ZSTD_getError(size_t code) { return ERR_getError(code); }
+/*! ZSTD_0_5_X_getError() :
+*   convert a `size_t` function result into a proper ZSTD_0_5_X_errorCode enum */
+ZSTD_0_5_X_ErrorCode ZSTD_0_5_X_getError(size_t code) { return ERR_getError(code); }
 
-/*! ZSTD_getErrorName() :
+/*! ZSTD_0_5_X_getErrorName() :
 *   provides error code string (useful for debugging) */
-const char* ZSTD_getErrorName(size_t code) { return ERR_getErrorName(code); }
+const char* ZSTD_0_5_X_getErrorName(size_t code) { return ERR_getErrorName(code); }
 
 
 /* *************************************************************
 *   Context management
 ***************************************************************/
 typedef enum { ZSTDds_getFrameHeaderSize, ZSTDds_decodeFrameHeader,
-               ZSTDds_decodeBlockHeader, ZSTDds_decompressBlock } ZSTD_dStage;
+               ZSTDds_decodeBlockHeader, ZSTDds_decompressBlock } ZSTD_0_5_X_dStage;
 
-struct ZSTD_DCtx_s
+struct ZSTD_0_5_X_DCtx_s
 {
-    FSE_DTable LLTable[FSE_DTABLE_SIZE_U32(LLFSELog)];
-    FSE_DTable OffTable[FSE_DTABLE_SIZE_U32(OffFSELog)];
-    FSE_DTable MLTable[FSE_DTABLE_SIZE_U32(MLFSELog)];
-    unsigned   hufTableX4[HUF_DTABLE_SIZE(HufLog)];
+    FSE_0_5_X_DTable LLTable[FSE_0_5_X_DTABLE_SIZE_U32(LLFSELog)];
+    FSE_0_5_X_DTable OffTable[FSE_0_5_X_DTABLE_SIZE_U32(OffFSELog)];
+    FSE_0_5_X_DTable MLTable[FSE_0_5_X_DTABLE_SIZE_U32(MLFSELog)];
+    unsigned   hufTableX4[HUF_0_5_X_DTABLE_SIZE(HufLog)];
     const void* previousDstEnd;
     const void* base;
     const void* vBase;
     const void* dictEnd;
     size_t expected;
     size_t headerSize;
-    ZSTD_parameters params;
-    blockType_t bType;   /* used in ZSTD_decompressContinue(), to transfer blockType between header decoding and block decoding stages */
-    ZSTD_dStage stage;
+    ZSTD_0_5_X_parameters params;
+    blockType_t bType;   /* used in ZSTD_0_5_X_decompressContinue(), to transfer blockType between header decoding and block decoding stages */
+    ZSTD_0_5_X_dStage stage;
     U32 flagStaticTables;
     const BYTE* litPtr;
     size_t litBufSize;
     size_t litSize;
     BYTE litBuffer[BLOCKSIZE + WILDCOPY_OVERLENGTH];
-    BYTE headerBuffer[ZSTD_frameHeaderSize_max];
-};  /* typedef'd to ZSTD_DCtx within "zstd_static.h" */
+    BYTE headerBuffer[ZSTD_0_5_X_frameHeaderSize_max];
+};  /* typedef'd to ZSTD_0_5_X_DCtx within "zstd_static.h" */
 
-size_t sizeofDCtx (void) { return sizeof(ZSTD_DCtx); }
+size_t sizeofDCtx_0_5_x (void) { return sizeof(ZSTD_0_5_X_DCtx); }
 
-size_t ZSTD_decompressBegin(ZSTD_DCtx* dctx)
+size_t ZSTD_0_5_X_decompressBegin(ZSTD_0_5_X_DCtx* dctx)
 {
-    dctx->expected = ZSTD_frameHeaderSize_min;
+    dctx->expected = ZSTD_0_5_X_frameHeaderSize_min;
     dctx->stage = ZSTDds_getFrameHeaderSize;
     dctx->previousDstEnd = NULL;
     dctx->base = NULL;
@@ -162,24 +162,24 @@ size_t ZSTD_decompressBegin(ZSTD_DCtx* dctx)
     return 0;
 }
 
-ZSTD_DCtx* ZSTD_createDCtx(void)
+ZSTD_0_5_X_DCtx* ZSTD_0_5_X_createDCtx(void)
 {
-    ZSTD_DCtx* dctx = (ZSTD_DCtx*)malloc(sizeof(ZSTD_DCtx));
+    ZSTD_0_5_X_DCtx* dctx = (ZSTD_0_5_X_DCtx*)malloc(sizeof(ZSTD_0_5_X_DCtx));
     if (dctx==NULL) return NULL;
-    ZSTD_decompressBegin(dctx);
+    ZSTD_0_5_X_decompressBegin(dctx);
     return dctx;
 }
 
-size_t ZSTD_freeDCtx(ZSTD_DCtx* dctx)
+size_t ZSTD_0_5_X_freeDCtx(ZSTD_0_5_X_DCtx* dctx)
 {
     free(dctx);
     return 0;   /* reserved as a potential error code in the future */
 }
 
-void ZSTD_copyDCtx(ZSTD_DCtx* dstDCtx, const ZSTD_DCtx* srcDCtx)
+void ZSTD_0_5_X_copyDCtx(ZSTD_0_5_X_DCtx* dstDCtx, const ZSTD_0_5_X_DCtx* srcDCtx)
 {
     memcpy(dstDCtx, srcDCtx,
-           sizeof(ZSTD_DCtx) - (BLOCKSIZE+WILDCOPY_OVERLENGTH + ZSTD_frameHeaderSize_max));  /* no need to copy workspace */
+           sizeof(ZSTD_0_5_X_DCtx) - (BLOCKSIZE+WILDCOPY_OVERLENGTH + ZSTD_0_5_X_frameHeaderSize_max));  /* no need to copy workspace */
 }
 
 
@@ -190,7 +190,7 @@ void ZSTD_copyDCtx(ZSTD_DCtx* dstDCtx, const ZSTD_DCtx* srcDCtx)
 /* Frame format description
    Frame Header -  [ Block Header - Block ] - Frame End
    1) Frame Header
-      - 4 bytes - Magic Number : ZSTD_MAGICNUMBER (defined within zstd_internal.h)
+      - 4 bytes - Magic Number : ZSTD_0_5_X_MAGICNUMBER (defined within zstd_internal.h)
       - 1 byte  - Window Descriptor
    2) Block Header
       - 3 bytes, starting with a 2-bits descriptor
@@ -268,50 +268,50 @@ void ZSTD_copyDCtx(ZSTD_DCtx* dstDCtx, const ZSTD_DCtx* srcDCtx)
 */
 
 
-/** ZSTD_decodeFrameHeader_Part1() :
+/** ZSTD_0_5_X_decodeFrameHeader_Part1() :
 *   decode the 1st part of the Frame Header, which tells Frame Header size.
-*   srcSize must be == ZSTD_frameHeaderSize_min.
+*   srcSize must be == ZSTD_0_5_X_frameHeaderSize_min.
 *   @return : the full size of the Frame Header */
-static size_t ZSTD_decodeFrameHeader_Part1(ZSTD_DCtx* zc, const void* src, size_t srcSize)
+static size_t ZSTD_0_5_X_decodeFrameHeader_Part1(ZSTD_0_5_X_DCtx* zc, const void* src, size_t srcSize)
 {
     U32 magicNumber;
-    if (srcSize != ZSTD_frameHeaderSize_min)
+    if (srcSize != ZSTD_0_5_X_frameHeaderSize_min)
         return ERROR(srcSize_wrong);
     magicNumber = MEM_readLE32(src);
-    if (magicNumber != ZSTD_MAGICNUMBER) return ERROR(prefix_unknown);
-    zc->headerSize = ZSTD_frameHeaderSize_min;
+    if (magicNumber != ZSTD_0_5_X_MAGICNUMBER) return ERROR(prefix_unknown);
+    zc->headerSize = ZSTD_0_5_X_frameHeaderSize_min;
     return zc->headerSize;
 }
 
 
-size_t ZSTD_getFrameParams(ZSTD_parameters* params, const void* src, size_t srcSize)
+size_t ZSTD_0_5_X_getFrameParams(ZSTD_0_5_X_parameters* params, const void* src, size_t srcSize)
 {
     U32 magicNumber;
-    if (srcSize < ZSTD_frameHeaderSize_min) return ZSTD_frameHeaderSize_max;
+    if (srcSize < ZSTD_0_5_X_frameHeaderSize_min) return ZSTD_0_5_X_frameHeaderSize_max;
     magicNumber = MEM_readLE32(src);
-    if (magicNumber != ZSTD_MAGICNUMBER) return ERROR(prefix_unknown);
+    if (magicNumber != ZSTD_0_5_X_MAGICNUMBER) return ERROR(prefix_unknown);
     memset(params, 0, sizeof(*params));
-    params->windowLog = (((const BYTE*)src)[4] & 15) + ZSTD_WINDOWLOG_ABSOLUTEMIN;
+    params->windowLog = (((const BYTE*)src)[4] & 15) + ZSTD_0_5_X_WINDOWLOG_ABSOLUTEMIN;
     if ((((const BYTE*)src)[4] >> 4) != 0) return ERROR(frameParameter_unsupported);   /* reserved bits */
     return 0;
 }
 
-/** ZSTD_decodeFrameHeader_Part2() :
+/** ZSTD_0_5_X_decodeFrameHeader_Part2() :
 *   decode the full Frame Header.
-*   srcSize must be the size provided by ZSTD_decodeFrameHeader_Part1().
-*   @return : 0, or an error code, which can be tested using ZSTD_isError() */
-static size_t ZSTD_decodeFrameHeader_Part2(ZSTD_DCtx* zc, const void* src, size_t srcSize)
+*   srcSize must be the size provided by ZSTD_0_5_X_decodeFrameHeader_Part1().
+*   @return : 0, or an error code, which can be tested using ZSTD_0_5_X_isError() */
+static size_t ZSTD_0_5_X_decodeFrameHeader_Part2(ZSTD_0_5_X_DCtx* zc, const void* src, size_t srcSize)
 {
     size_t result;
     if (srcSize != zc->headerSize)
         return ERROR(srcSize_wrong);
-    result = ZSTD_getFrameParams(&(zc->params), src, srcSize);
+    result = ZSTD_0_5_X_getFrameParams(&(zc->params), src, srcSize);
     if ((MEM_32bits()) && (zc->params.windowLog > 25)) return ERROR(frameParameter_unsupportedBy32bits);
     return result;
 }
 
 
-size_t ZSTD_getcBlockSize(const void* src, size_t srcSize, blockProperties_t* bpPtr)
+size_t ZSTD_0_5_X_getcBlockSize(const void* src, size_t srcSize, blockProperties_t* bpPtr)
 {
     const BYTE* const in = (const BYTE* const)src;
     BYTE headerFlags;
@@ -332,7 +332,7 @@ size_t ZSTD_getcBlockSize(const void* src, size_t srcSize, blockProperties_t* bp
 }
 
 
-static size_t ZSTD_copyRawBlock(void* dst, size_t maxDstSize, const void* src, size_t srcSize)
+static size_t ZSTD_0_5_X_copyRawBlock(void* dst, size_t maxDstSize, const void* src, size_t srcSize)
 {
     if (srcSize > maxDstSize) return ERROR(dstSize_tooSmall);
     memcpy(dst, src, srcSize);
@@ -340,9 +340,9 @@ static size_t ZSTD_copyRawBlock(void* dst, size_t maxDstSize, const void* src, s
 }
 
 
-/*! ZSTD_decodeLiteralsBlock() :
+/*! ZSTD_0_5_X_decodeLiteralsBlock() :
     @return : nb of bytes read from src (< srcSize ) */
-size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
+size_t ZSTD_0_5_X_decodeLiteralsBlock(ZSTD_0_5_X_DCtx* dctx,
                           const void* src, size_t srcSize)   /* note : srcSize < BLOCKSIZE */
 {
     const BYTE* const istart = (const BYTE*) src;
@@ -380,9 +380,9 @@ size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
             }
             if (litSize > BLOCKSIZE) return ERROR(corruption_detected);
 
-            if (HUF_isError(singleStream ?
-                            HUF_decompress1X2(dctx->litBuffer, litSize, istart+lhSize, litCSize) :
-                            HUF_decompress   (dctx->litBuffer, litSize, istart+lhSize, litCSize) ))
+            if (HUF_0_5_X_isError(singleStream ?
+                            HUF_0_5_X_decompress1X2(dctx->litBuffer, litSize, istart+lhSize, litCSize) :
+                            HUF_0_5_X_decompress   (dctx->litBuffer, litSize, istart+lhSize, litCSize) ))
                 return ERROR(corruption_detected);
 
             dctx->litPtr = dctx->litBuffer;
@@ -405,8 +405,8 @@ size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
             litSize  = ((istart[0] & 15) << 6) + (istart[1] >> 2);
             litCSize = ((istart[1] &  3) << 8) + istart[2];
 
-            errorCode = HUF_decompress1X4_usingDTable(dctx->litBuffer, litSize, istart+lhSize, litCSize, dctx->hufTableX4);
-            if (HUF_isError(errorCode)) return ERROR(corruption_detected);
+            errorCode = HUF_0_5_X_decompress1X4_usingDTable(dctx->litBuffer, litSize, istart+lhSize, litCSize, dctx->hufTableX4);
+            if (HUF_0_5_X_isError(errorCode)) return ERROR(corruption_detected);
 
             dctx->litPtr = dctx->litBuffer;
             dctx->litBufSize = BLOCKSIZE+WILDCOPY_OVERLENGTH;
@@ -475,8 +475,8 @@ size_t ZSTD_decodeLiteralsBlock(ZSTD_DCtx* dctx,
 }
 
 
-size_t ZSTD_decodeSeqHeaders(int* nbSeq, const BYTE** dumpsPtr, size_t* dumpsLengthPtr,
-                         FSE_DTable* DTableLL, FSE_DTable* DTableML, FSE_DTable* DTableOffb,
+size_t ZSTD_0_5_X_decodeSeqHeaders(int* nbSeq, const BYTE** dumpsPtr, size_t* dumpsLengthPtr,
+                         FSE_0_5_X_DTable* DTableLL, FSE_0_5_X_DTable* DTableML, FSE_0_5_X_DTable* DTableOffb,
                          const void* src, size_t srcSize)
 {
     const BYTE* const istart = (const BYTE* const)src;
@@ -524,72 +524,72 @@ size_t ZSTD_decodeSeqHeaders(int* nbSeq, const BYTE** dumpsPtr, size_t* dumpsLen
         switch(LLtype)
         {
         U32 max;
-        case FSE_ENCODING_RLE :
+        case FSE_0_5_X_ENCODING_RLE :
             LLlog = 0;
-            FSE_buildDTable_rle(DTableLL, *ip++);
+            FSE_0_5_X_buildDTable_rle(DTableLL, *ip++);
             break;
-        case FSE_ENCODING_RAW :
+        case FSE_0_5_X_ENCODING_RAW :
             LLlog = LLbits;
-            FSE_buildDTable_raw(DTableLL, LLbits);
+            FSE_0_5_X_buildDTable_raw(DTableLL, LLbits);
             break;
-        case FSE_ENCODING_STATIC:
+        case FSE_0_5_X_ENCODING_STATIC:
             break;
-        case FSE_ENCODING_DYNAMIC :
+        case FSE_0_5_X_ENCODING_DYNAMIC :
         default :   /* impossible */
             max = MaxLL;
-            headerSize = FSE_readNCount(norm, &max, &LLlog, ip, iend-ip);
-            if (FSE_isError(headerSize)) return ERROR(GENERIC);
+            headerSize = FSE_0_5_X_readNCount(norm, &max, &LLlog, ip, iend-ip);
+            if (FSE_0_5_X_isError(headerSize)) return ERROR(GENERIC);
             if (LLlog > LLFSELog) return ERROR(corruption_detected);
             ip += headerSize;
-            FSE_buildDTable(DTableLL, norm, max, LLlog);
+            FSE_0_5_X_buildDTable(DTableLL, norm, max, LLlog);
         }
 
         switch(Offtype)
         {
         U32 max;
-        case FSE_ENCODING_RLE :
+        case FSE_0_5_X_ENCODING_RLE :
             Offlog = 0;
             if (ip > iend-2) return ERROR(srcSize_wrong);   /* min : "raw", hence no header, but at least xxLog bits */
-            FSE_buildDTable_rle(DTableOffb, *ip++ & MaxOff); /* if *ip > MaxOff, data is corrupted */
+            FSE_0_5_X_buildDTable_rle(DTableOffb, *ip++ & MaxOff); /* if *ip > MaxOff, data is corrupted */
             break;
-        case FSE_ENCODING_RAW :
+        case FSE_0_5_X_ENCODING_RAW :
             Offlog = Offbits;
-            FSE_buildDTable_raw(DTableOffb, Offbits);
+            FSE_0_5_X_buildDTable_raw(DTableOffb, Offbits);
             break;
-        case FSE_ENCODING_STATIC:
+        case FSE_0_5_X_ENCODING_STATIC:
             break;
-        case FSE_ENCODING_DYNAMIC :
+        case FSE_0_5_X_ENCODING_DYNAMIC :
         default :   /* impossible */
             max = MaxOff;
-            headerSize = FSE_readNCount(norm, &max, &Offlog, ip, iend-ip);
-            if (FSE_isError(headerSize)) return ERROR(GENERIC);
+            headerSize = FSE_0_5_X_readNCount(norm, &max, &Offlog, ip, iend-ip);
+            if (FSE_0_5_X_isError(headerSize)) return ERROR(GENERIC);
             if (Offlog > OffFSELog) return ERROR(corruption_detected);
             ip += headerSize;
-            FSE_buildDTable(DTableOffb, norm, max, Offlog);
+            FSE_0_5_X_buildDTable(DTableOffb, norm, max, Offlog);
         }
 
         switch(MLtype)
         {
         U32 max;
-        case FSE_ENCODING_RLE :
+        case FSE_0_5_X_ENCODING_RLE :
             MLlog = 0;
             if (ip > iend-2) return ERROR(srcSize_wrong); /* min : "raw", hence no header, but at least xxLog bits */
-            FSE_buildDTable_rle(DTableML, *ip++);
+            FSE_0_5_X_buildDTable_rle(DTableML, *ip++);
             break;
-        case FSE_ENCODING_RAW :
+        case FSE_0_5_X_ENCODING_RAW :
             MLlog = MLbits;
-            FSE_buildDTable_raw(DTableML, MLbits);
+            FSE_0_5_X_buildDTable_raw(DTableML, MLbits);
             break;
-        case FSE_ENCODING_STATIC:
+        case FSE_0_5_X_ENCODING_STATIC:
             break;
-        case FSE_ENCODING_DYNAMIC :
+        case FSE_0_5_X_ENCODING_DYNAMIC :
         default :   /* impossible */
             max = MaxML;
-            headerSize = FSE_readNCount(norm, &max, &MLlog, ip, iend-ip);
-            if (FSE_isError(headerSize)) return ERROR(GENERIC);
+            headerSize = FSE_0_5_X_readNCount(norm, &max, &MLlog, ip, iend-ip);
+            if (FSE_0_5_X_isError(headerSize)) return ERROR(GENERIC);
             if (MLlog > MLFSELog) return ERROR(corruption_detected);
             ip += headerSize;
-            FSE_buildDTable(DTableML, norm, max, MLlog);
+            FSE_0_5_X_buildDTable(DTableML, norm, max, MLlog);
     }   }
 
     return ip-istart;
@@ -604,15 +604,15 @@ typedef struct {
 
 typedef struct {
     BIT_DStream_t DStream;
-    FSE_DState_t stateLL;
-    FSE_DState_t stateOffb;
-    FSE_DState_t stateML;
+    FSE_0_5_X_DState_t stateLL;
+    FSE_0_5_X_DState_t stateOffb;
+    FSE_0_5_X_DState_t stateML;
     size_t prevOffset;
     const BYTE* dumps;
     const BYTE* dumpsEnd;
 } seqState_t;
 
-static void ZSTD_decodeSequence(seq_t* seq, seqState_t* seqState)
+static void ZSTD_0_5_X_decodeSequence(seq_t* seq, seqState_t* seqState)
 {
     size_t litLength;
     size_t prevOffset;
@@ -622,7 +622,7 @@ static void ZSTD_decodeSequence(seq_t* seq, seqState_t* seqState)
     const BYTE* const de = seqState->dumpsEnd;
 
     /* Literal length */
-    litLength = FSE_peakSymbol(&(seqState->stateLL));
+    litLength = FSE_0_5_X_peakSymbol(&(seqState->stateLL));
     prevOffset = litLength ? seq->offset : seqState->prevOffset;
     if (litLength == MaxLL) {
         U32 add = *dumps++;
@@ -641,22 +641,22 @@ static void ZSTD_decodeSequence(seq_t* seq, seqState_t* seqState)
                 1 /*fake*/, 1, 2, 4, 8, 16, 32, 64, 128, 256,
                 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144,
                 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, /*fake*/ 1, 1, 1, 1, 1 };
-        U32 offsetCode = FSE_peakSymbol(&(seqState->stateOffb));   /* <= maxOff, by table construction */
+        U32 offsetCode = FSE_0_5_X_peakSymbol(&(seqState->stateOffb));   /* <= maxOff, by table construction */
         U32 nbBits = offsetCode - 1;
         if (offsetCode==0) nbBits = 0;   /* cmove */
         offset = offsetPrefix[offsetCode] + BIT_readBits(&(seqState->DStream), nbBits);
         if (MEM_32bits()) BIT_reloadDStream(&(seqState->DStream));
         if (offsetCode==0) offset = prevOffset;   /* repcode, cmove */
         if (offsetCode | !litLength) seqState->prevOffset = seq->offset;   /* cmove */
-        FSE_decodeSymbol(&(seqState->stateOffb), &(seqState->DStream));    /* update */
+        FSE_0_5_X_decodeSymbol(&(seqState->stateOffb), &(seqState->DStream));    /* update */
     }
 
     /* Literal length update */
-    FSE_decodeSymbol(&(seqState->stateLL), &(seqState->DStream));   /* update */
+    FSE_0_5_X_decodeSymbol(&(seqState->stateLL), &(seqState->DStream));   /* update */
     if (MEM_32bits()) BIT_reloadDStream(&(seqState->DStream));
 
     /* MatchLength */
-    matchLength = FSE_decodeSymbol(&(seqState->stateML), &(seqState->DStream));
+    matchLength = FSE_0_5_X_decodeSymbol(&(seqState->stateML), &(seqState->DStream));
     if (matchLength == MaxML) {
         U32 add = *dumps++;
         if (add < 255) matchLength += add;
@@ -686,7 +686,7 @@ static void ZSTD_decodeSequence(seq_t* seq, seqState_t* seqState)
 }
 
 
-FORCE_INLINE size_t ZSTD_execSequence(BYTE* op,
+FORCE_INLINE size_t ZSTD_0_5_X_execSequence(BYTE* op,
                                 BYTE* const oend, seq_t sequence,
                                 const BYTE** litPtr, const BYTE* const litLimit_8,
                                 const BYTE* const base, const BYTE* const vBase, const BYTE* const dictEnd)
@@ -706,7 +706,7 @@ FORCE_INLINE size_t ZSTD_execSequence(BYTE* op,
     if (litEnd > litLimit_8) return ERROR(corruption_detected);   /* risk read beyond lit buffer */
 
     /* copy Literals */
-    ZSTD_wildcopy(op, *litPtr, sequence.litLength);   /* note : oLitEnd <= oend-8 : no risk of overwrite beyond oend */
+    ZSTD_0_5_X_wildcopy(op, *litPtr, sequence.litLength);   /* note : oLitEnd <= oend-8 : no risk of overwrite beyond oend */
     op = oLitEnd;
     *litPtr = litEnd;   /* update for next sequence */
 
@@ -738,30 +738,30 @@ FORCE_INLINE size_t ZSTD_execSequence(BYTE* op,
         op[2] = match[2];
         op[3] = match[3];
         match += dec32table[sequence.offset];
-        ZSTD_copy4(op+4, match);
+        ZSTD_0_5_X_copy4(op+4, match);
         match -= sub2;
     } else {
-        ZSTD_copy8(op, match);
+        ZSTD_0_5_X_copy8(op, match);
     }
     op += 8; match += 8;
 
     if (oMatchEnd > oend-12) {
         if (op < oend_8) {
-            ZSTD_wildcopy(op, match, oend_8 - op);
+            ZSTD_0_5_X_wildcopy(op, match, oend_8 - op);
             match += oend_8 - op;
             op = oend_8;
         }
         while (op < oMatchEnd)
             *op++ = *match++;
     } else {
-        ZSTD_wildcopy(op, match, sequence.matchLength-8);   /* works even if matchLength < 8 */
+        ZSTD_0_5_X_wildcopy(op, match, sequence.matchLength-8);   /* works even if matchLength < 8 */
     }
     return sequenceLength;
 }
 
 
-static size_t ZSTD_decompressSequences(
-                               ZSTD_DCtx* dctx,
+static size_t ZSTD_0_5_X_decompressSequences(
+                               ZSTD_0_5_X_DCtx* dctx,
                                void* dst, size_t maxDstSize,
                          const void* seqStart, size_t seqSize)
 {
@@ -784,10 +784,10 @@ static size_t ZSTD_decompressSequences(
     const BYTE* const dictEnd = (const BYTE*) (dctx->dictEnd);
 
     /* Build Decoding Tables */
-    errorCode = ZSTD_decodeSeqHeaders(&nbSeq, &dumps, &dumpsLength,
+    errorCode = ZSTD_0_5_X_decodeSeqHeaders(&nbSeq, &dumps, &dumpsLength,
                                       DTableLL, DTableML, DTableOffb,
                                       ip, seqSize);
-    if (ZSTD_isError(errorCode)) return errorCode;
+    if (ZSTD_0_5_X_isError(errorCode)) return errorCode;
     ip += errorCode;
 
     /* Regen sequences */
@@ -802,16 +802,16 @@ static size_t ZSTD_decompressSequences(
         seqState.prevOffset = REPCODE_STARTVALUE;
         errorCode = BIT_initDStream(&(seqState.DStream), ip, iend-ip);
         if (ERR_isError(errorCode)) return ERROR(corruption_detected);
-        FSE_initDState(&(seqState.stateLL), &(seqState.DStream), DTableLL);
-        FSE_initDState(&(seqState.stateOffb), &(seqState.DStream), DTableOffb);
-        FSE_initDState(&(seqState.stateML), &(seqState.DStream), DTableML);
+        FSE_0_5_X_initDState(&(seqState.stateLL), &(seqState.DStream), DTableLL);
+        FSE_0_5_X_initDState(&(seqState.stateOffb), &(seqState.DStream), DTableOffb);
+        FSE_0_5_X_initDState(&(seqState.stateML), &(seqState.DStream), DTableML);
 
         for ( ; (BIT_reloadDStream(&(seqState.DStream)) <= BIT_DStream_completed) && nbSeq ; ) {
             size_t oneSeqSize;
             nbSeq--;
-            ZSTD_decodeSequence(&sequence, &seqState);
-            oneSeqSize = ZSTD_execSequence(op, oend, sequence, &litPtr, litLimit_8, base, vBase, dictEnd);
-            if (ZSTD_isError(oneSeqSize)) return oneSeqSize;
+            ZSTD_0_5_X_decodeSequence(&sequence, &seqState);
+            oneSeqSize = ZSTD_0_5_X_execSequence(op, oend, sequence, &litPtr, litLimit_8, base, vBase, dictEnd);
+            if (ZSTD_0_5_X_isError(oneSeqSize)) return oneSeqSize;
             op += oneSeqSize;
         }
 
@@ -832,7 +832,7 @@ static size_t ZSTD_decompressSequences(
 }
 
 
-static void ZSTD_checkContinuity(ZSTD_DCtx* dctx, const void* dst)
+static void ZSTD_0_5_X_checkContinuity(ZSTD_0_5_X_DCtx* dctx, const void* dst)
 {
     if (dst != dctx->previousDstEnd) {   /* not contiguous */
         dctx->dictEnd = dctx->previousDstEnd;
@@ -843,7 +843,7 @@ static void ZSTD_checkContinuity(ZSTD_DCtx* dctx, const void* dst)
 }
 
 
-static size_t ZSTD_decompressBlock_internal(ZSTD_DCtx* dctx,
+static size_t ZSTD_0_5_X_decompressBlock_internal(ZSTD_0_5_X_DCtx* dctx,
                             void* dst, size_t dstCapacity,
                       const void* src, size_t srcSize)
 {   /* blockType == blockCompressed */
@@ -853,27 +853,27 @@ static size_t ZSTD_decompressBlock_internal(ZSTD_DCtx* dctx,
     if (srcSize >= BLOCKSIZE) return ERROR(srcSize_wrong);
 
     /* Decode literals sub-block */
-    litCSize = ZSTD_decodeLiteralsBlock(dctx, src, srcSize);
-    if (ZSTD_isError(litCSize)) return litCSize;
+    litCSize = ZSTD_0_5_X_decodeLiteralsBlock(dctx, src, srcSize);
+    if (ZSTD_0_5_X_isError(litCSize)) return litCSize;
     ip += litCSize;
     srcSize -= litCSize;
 
-    return ZSTD_decompressSequences(dctx, dst, dstCapacity, ip, srcSize);
+    return ZSTD_0_5_X_decompressSequences(dctx, dst, dstCapacity, ip, srcSize);
 }
 
 
-size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx,
+size_t ZSTD_0_5_X_decompressBlock(ZSTD_0_5_X_DCtx* dctx,
                             void* dst, size_t dstCapacity,
                       const void* src, size_t srcSize)
 {
-    ZSTD_checkContinuity(dctx, dst);
-    return ZSTD_decompressBlock_internal(dctx, dst, dstCapacity, src, srcSize);
+    ZSTD_0_5_X_checkContinuity(dctx, dst);
+    return ZSTD_0_5_X_decompressBlock_internal(dctx, dst, dstCapacity, src, srcSize);
 }
 
 
-/*! ZSTD_decompress_continueDCtx
+/*! ZSTD_0_5_X_decompress_continueDCtx
 *   dctx must have been properly initialized */
-static size_t ZSTD_decompress_continueDCtx(ZSTD_DCtx* dctx,
+static size_t ZSTD_0_5_X_decompress_continueDCtx(ZSTD_0_5_X_DCtx* dctx,
                                  void* dst, size_t maxDstSize,
                                  const void* src, size_t srcSize)
 {
@@ -888,40 +888,40 @@ static size_t ZSTD_decompress_continueDCtx(ZSTD_DCtx* dctx,
     /* Frame Header */
     {
         size_t frameHeaderSize;
-        if (srcSize < ZSTD_frameHeaderSize_min+ZSTD_blockHeaderSize) return ERROR(srcSize_wrong);
-#if defined(ZSTD_LEGACY_SUPPORT) && (ZSTD_LEGACY_SUPPORT==1)
+        if (srcSize < ZSTD_0_5_X_frameHeaderSize_min+ZSTD_0_5_X_blockHeaderSize) return ERROR(srcSize_wrong);
+#if defined(ZSTD_0_5_X_LEGACY_SUPPORT) && (ZSTD_0_5_X_LEGACY_SUPPORT==1)
         {
             const U32 magicNumber = MEM_readLE32(src);
-            if (ZSTD_isLegacy(magicNumber))
-                return ZSTD_decompressLegacy(dst, maxDstSize, src, srcSize, magicNumber);
+            if (ZSTD_0_5_X_isLegacy(magicNumber))
+                return ZSTD_0_5_X_decompressLegacy(dst, maxDstSize, src, srcSize, magicNumber);
         }
 #endif
-        frameHeaderSize = ZSTD_decodeFrameHeader_Part1(dctx, src, ZSTD_frameHeaderSize_min);
-        if (ZSTD_isError(frameHeaderSize)) return frameHeaderSize;
-        if (srcSize < frameHeaderSize+ZSTD_blockHeaderSize) return ERROR(srcSize_wrong);
+        frameHeaderSize = ZSTD_0_5_X_decodeFrameHeader_Part1(dctx, src, ZSTD_0_5_X_frameHeaderSize_min);
+        if (ZSTD_0_5_X_isError(frameHeaderSize)) return frameHeaderSize;
+        if (srcSize < frameHeaderSize+ZSTD_0_5_X_blockHeaderSize) return ERROR(srcSize_wrong);
         ip += frameHeaderSize; remainingSize -= frameHeaderSize;
-        frameHeaderSize = ZSTD_decodeFrameHeader_Part2(dctx, src, frameHeaderSize);
-        if (ZSTD_isError(frameHeaderSize)) return frameHeaderSize;
+        frameHeaderSize = ZSTD_0_5_X_decodeFrameHeader_Part2(dctx, src, frameHeaderSize);
+        if (ZSTD_0_5_X_isError(frameHeaderSize)) return frameHeaderSize;
     }
 
     /* Loop on each block */
     while (1)
     {
         size_t decodedSize=0;
-        size_t cBlockSize = ZSTD_getcBlockSize(ip, iend-ip, &blockProperties);
-        if (ZSTD_isError(cBlockSize)) return cBlockSize;
+        size_t cBlockSize = ZSTD_0_5_X_getcBlockSize(ip, iend-ip, &blockProperties);
+        if (ZSTD_0_5_X_isError(cBlockSize)) return cBlockSize;
 
-        ip += ZSTD_blockHeaderSize;
-        remainingSize -= ZSTD_blockHeaderSize;
+        ip += ZSTD_0_5_X_blockHeaderSize;
+        remainingSize -= ZSTD_0_5_X_blockHeaderSize;
         if (cBlockSize > remainingSize) return ERROR(srcSize_wrong);
 
         switch(blockProperties.blockType)
         {
         case bt_compressed:
-            decodedSize = ZSTD_decompressBlock_internal(dctx, op, oend-op, ip, cBlockSize);
+            decodedSize = ZSTD_0_5_X_decompressBlock_internal(dctx, op, oend-op, ip, cBlockSize);
             break;
         case bt_raw :
-            decodedSize = ZSTD_copyRawBlock(op, oend-op, ip, cBlockSize);
+            decodedSize = ZSTD_0_5_X_copyRawBlock(op, oend-op, ip, cBlockSize);
             break;
         case bt_rle :
             return ERROR(GENERIC);   /* not yet supported */
@@ -935,7 +935,7 @@ static size_t ZSTD_decompress_continueDCtx(ZSTD_DCtx* dctx,
         }
         if (cBlockSize == 0) break;   /* bt_end */
 
-        if (ZSTD_isError(decodedSize)) return decodedSize;
+        if (ZSTD_0_5_X_isError(decodedSize)) return decodedSize;
         op += decodedSize;
         ip += cBlockSize;
         remainingSize -= cBlockSize;
@@ -945,44 +945,44 @@ static size_t ZSTD_decompress_continueDCtx(ZSTD_DCtx* dctx,
 }
 
 
-size_t ZSTD_decompress_usingPreparedDCtx(ZSTD_DCtx* dctx, const ZSTD_DCtx* refDCtx,
+size_t ZSTD_0_5_X_decompress_usingPreparedDCtx(ZSTD_0_5_X_DCtx* dctx, const ZSTD_0_5_X_DCtx* refDCtx,
                                          void* dst, size_t maxDstSize,
                                    const void* src, size_t srcSize)
 {
-    ZSTD_copyDCtx(dctx, refDCtx);
-    ZSTD_checkContinuity(dctx, dst);
-    return ZSTD_decompress_continueDCtx(dctx, dst, maxDstSize, src, srcSize);
+    ZSTD_0_5_X_copyDCtx(dctx, refDCtx);
+    ZSTD_0_5_X_checkContinuity(dctx, dst);
+    return ZSTD_0_5_X_decompress_continueDCtx(dctx, dst, maxDstSize, src, srcSize);
 }
 
 
-size_t ZSTD_decompress_usingDict(ZSTD_DCtx* dctx,
+size_t ZSTD_0_5_X_decompress_usingDict(ZSTD_0_5_X_DCtx* dctx,
                                  void* dst, size_t maxDstSize,
                                  const void* src, size_t srcSize,
                                  const void* dict, size_t dictSize)
 {
-    ZSTD_decompressBegin_usingDict(dctx, dict, dictSize);
-    ZSTD_checkContinuity(dctx, dst);
-    return ZSTD_decompress_continueDCtx(dctx, dst, maxDstSize, src, srcSize);
+    ZSTD_0_5_X_decompressBegin_usingDict(dctx, dict, dictSize);
+    ZSTD_0_5_X_checkContinuity(dctx, dst);
+    return ZSTD_0_5_X_decompress_continueDCtx(dctx, dst, maxDstSize, src, srcSize);
 }
 
 
-size_t ZSTD_decompressDCtx(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize)
+size_t ZSTD_0_5_X_decompressDCtx(ZSTD_0_5_X_DCtx* dctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize)
 {
-    return ZSTD_decompress_usingDict(dctx, dst, maxDstSize, src, srcSize, NULL, 0);
+    return ZSTD_0_5_X_decompress_usingDict(dctx, dst, maxDstSize, src, srcSize, NULL, 0);
 }
 
-size_t ZSTD_decompress(void* dst, size_t maxDstSize, const void* src, size_t srcSize)
+size_t ZSTD_0_5_X_decompress(void* dst, size_t maxDstSize, const void* src, size_t srcSize)
 {
-#if defined(ZSTD_HEAPMODE) && (ZSTD_HEAPMODE==1)
+#if defined(ZSTD_0_5_X_HEAPMODE) && (ZSTD_0_5_X_HEAPMODE==1)
     size_t regenSize;
-    ZSTD_DCtx* dctx = ZSTD_createDCtx();
+    ZSTD_0_5_X_DCtx* dctx = ZSTD_0_5_X_createDCtx();
     if (dctx==NULL) return ERROR(memory_allocation);
-    regenSize = ZSTD_decompressDCtx(dctx, dst, maxDstSize, src, srcSize);
-    ZSTD_freeDCtx(dctx);
+    regenSize = ZSTD_0_5_X_decompressDCtx(dctx, dst, maxDstSize, src, srcSize);
+    ZSTD_0_5_X_freeDCtx(dctx);
     return regenSize;
 #else
-    ZSTD_DCtx dctx;
-    return ZSTD_decompressDCtx(&dctx, dst, maxDstSize, src, srcSize);
+    ZSTD_0_5_X_DCtx dctx;
+    return ZSTD_0_5_X_decompressDCtx(&dctx, dst, maxDstSize, src, srcSize);
 #endif
 }
 
@@ -990,16 +990,16 @@ size_t ZSTD_decompress(void* dst, size_t maxDstSize, const void* src, size_t src
 /* ******************************
 *  Streaming Decompression API
 ********************************/
-size_t ZSTD_nextSrcSizeToDecompress(ZSTD_DCtx* dctx)
+size_t ZSTD_0_5_X_nextSrcSizeToDecompress(ZSTD_0_5_X_DCtx* dctx)
 {
     return dctx->expected;
 }
 
-size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize)
+size_t ZSTD_0_5_X_decompressContinue(ZSTD_0_5_X_DCtx* dctx, void* dst, size_t maxDstSize, const void* src, size_t srcSize)
 {
     /* Sanity check */
     if (srcSize != dctx->expected) return ERROR(srcSize_wrong);
-    ZSTD_checkContinuity(dctx, dst);
+    ZSTD_0_5_X_checkContinuity(dctx, dst);
 
     /* Decompress : frame header; part 1 */
     switch (dctx->stage)
@@ -1007,12 +1007,12 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, co
     case ZSTDds_getFrameHeaderSize :
         {
             /* get frame header size */
-            if (srcSize != ZSTD_frameHeaderSize_min) return ERROR(srcSize_wrong);   /* impossible */
-            dctx->headerSize = ZSTD_decodeFrameHeader_Part1(dctx, src, ZSTD_frameHeaderSize_min);
-            if (ZSTD_isError(dctx->headerSize)) return dctx->headerSize;
-            memcpy(dctx->headerBuffer, src, ZSTD_frameHeaderSize_min);
-            if (dctx->headerSize > ZSTD_frameHeaderSize_min) {
-                dctx->expected = dctx->headerSize - ZSTD_frameHeaderSize_min;
+            if (srcSize != ZSTD_0_5_X_frameHeaderSize_min) return ERROR(srcSize_wrong);   /* impossible */
+            dctx->headerSize = ZSTD_0_5_X_decodeFrameHeader_Part1(dctx, src, ZSTD_0_5_X_frameHeaderSize_min);
+            if (ZSTD_0_5_X_isError(dctx->headerSize)) return dctx->headerSize;
+            memcpy(dctx->headerBuffer, src, ZSTD_0_5_X_frameHeaderSize_min);
+            if (dctx->headerSize > ZSTD_0_5_X_frameHeaderSize_min) {
+                dctx->expected = dctx->headerSize - ZSTD_0_5_X_frameHeaderSize_min;
                 dctx->stage = ZSTDds_decodeFrameHeader;
                 return 0;
             }
@@ -1022,10 +1022,10 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, co
         {
             /* get frame header */
             size_t result;
-            memcpy(dctx->headerBuffer + ZSTD_frameHeaderSize_min, src, dctx->expected);
-            result = ZSTD_decodeFrameHeader_Part2(dctx, dctx->headerBuffer, dctx->headerSize);
-            if (ZSTD_isError(result)) return result;
-            dctx->expected = ZSTD_blockHeaderSize;
+            memcpy(dctx->headerBuffer + ZSTD_0_5_X_frameHeaderSize_min, src, dctx->expected);
+            result = ZSTD_0_5_X_decodeFrameHeader_Part2(dctx, dctx->headerBuffer, dctx->headerSize);
+            if (ZSTD_0_5_X_isError(result)) return result;
+            dctx->expected = ZSTD_0_5_X_blockHeaderSize;
             dctx->stage = ZSTDds_decodeBlockHeader;
             return 0;
         }
@@ -1033,8 +1033,8 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, co
         {
             /* Decode block header */
             blockProperties_t bp;
-            size_t blockSize = ZSTD_getcBlockSize(src, ZSTD_blockHeaderSize, &bp);
-            if (ZSTD_isError(blockSize)) return blockSize;
+            size_t blockSize = ZSTD_0_5_X_getcBlockSize(src, ZSTD_0_5_X_blockHeaderSize, &bp);
+            if (ZSTD_0_5_X_isError(blockSize)) return blockSize;
             if (bp.blockType == bt_end) {
                 dctx->expected = 0;
                 dctx->stage = ZSTDds_getFrameHeaderSize;
@@ -1053,10 +1053,10 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, co
             switch(dctx->bType)
             {
             case bt_compressed:
-                rSize = ZSTD_decompressBlock_internal(dctx, dst, maxDstSize, src, srcSize);
+                rSize = ZSTD_0_5_X_decompressBlock_internal(dctx, dst, maxDstSize, src, srcSize);
                 break;
             case bt_raw :
-                rSize = ZSTD_copyRawBlock(dst, maxDstSize, src, srcSize);
+                rSize = ZSTD_0_5_X_copyRawBlock(dst, maxDstSize, src, srcSize);
                 break;
             case bt_rle :
                 return ERROR(GENERIC);   /* not yet handled */
@@ -1068,7 +1068,7 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, co
                 return ERROR(GENERIC);   /* impossible */
             }
             dctx->stage = ZSTDds_decodeBlockHeader;
-            dctx->expected = ZSTD_blockHeaderSize;
+            dctx->expected = ZSTD_0_5_X_blockHeaderSize;
             dctx->previousDstEnd = (char*)dst + rSize;
             return rSize;
         }
@@ -1078,7 +1078,7 @@ size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t maxDstSize, co
 }
 
 
-static void ZSTD_refDictContent(ZSTD_DCtx* dctx, const void* dict, size_t dictSize)
+static void ZSTD_0_5_X_refDictContent(ZSTD_0_5_X_DCtx* dctx, const void* dict, size_t dictSize)
 {
     dctx->dictEnd = dctx->previousDstEnd;
     dctx->vBase = (const char*)dict - ((const char*)(dctx->previousDstEnd) - (const char*)(dctx->base));
@@ -1086,7 +1086,7 @@ static void ZSTD_refDictContent(ZSTD_DCtx* dctx, const void* dict, size_t dictSi
     dctx->previousDstEnd = (const char*)dict + dictSize;
 }
 
-static size_t ZSTD_loadEntropy(ZSTD_DCtx* dctx, const void* dict, size_t dictSize)
+static size_t ZSTD_0_5_X_loadEntropy(ZSTD_0_5_X_DCtx* dctx, const void* dict, size_t dictSize)
 {
     size_t hSize, offcodeHeaderSize, matchlengthHeaderSize, errorCode, litlengthHeaderSize;
     short offcodeNCount[MaxOff+1];
@@ -1096,67 +1096,67 @@ static size_t ZSTD_loadEntropy(ZSTD_DCtx* dctx, const void* dict, size_t dictSiz
     short litlengthNCount[MaxLL+1];
     unsigned litlengthMaxValue = MaxLL, litlengthLog = LLFSELog;
 
-    hSize = HUF_readDTableX4(dctx->hufTableX4, dict, dictSize);
-    if (HUF_isError(hSize)) return ERROR(dictionary_corrupted);
+    hSize = HUF_0_5_X_readDTableX4(dctx->hufTableX4, dict, dictSize);
+    if (HUF_0_5_X_isError(hSize)) return ERROR(dictionary_corrupted);
     dict = (const char*)dict + hSize;
     dictSize -= hSize;
 
-    offcodeHeaderSize = FSE_readNCount(offcodeNCount, &offcodeMaxValue, &offcodeLog, dict, dictSize);
-    if (FSE_isError(offcodeHeaderSize)) return ERROR(dictionary_corrupted);
-    errorCode = FSE_buildDTable(dctx->OffTable, offcodeNCount, offcodeMaxValue, offcodeLog);
-    if (FSE_isError(errorCode)) return ERROR(dictionary_corrupted);
+    offcodeHeaderSize = FSE_0_5_X_readNCount(offcodeNCount, &offcodeMaxValue, &offcodeLog, dict, dictSize);
+    if (FSE_0_5_X_isError(offcodeHeaderSize)) return ERROR(dictionary_corrupted);
+    errorCode = FSE_0_5_X_buildDTable(dctx->OffTable, offcodeNCount, offcodeMaxValue, offcodeLog);
+    if (FSE_0_5_X_isError(errorCode)) return ERROR(dictionary_corrupted);
     dict = (const char*)dict + offcodeHeaderSize;
     dictSize -= offcodeHeaderSize;
 
-    matchlengthHeaderSize = FSE_readNCount(matchlengthNCount, &matchlengthMaxValue, &matchlengthLog, dict, dictSize);
-    if (FSE_isError(matchlengthHeaderSize)) return ERROR(dictionary_corrupted);
-    errorCode = FSE_buildDTable(dctx->MLTable, matchlengthNCount, matchlengthMaxValue, matchlengthLog);
-    if (FSE_isError(errorCode)) return ERROR(dictionary_corrupted);
+    matchlengthHeaderSize = FSE_0_5_X_readNCount(matchlengthNCount, &matchlengthMaxValue, &matchlengthLog, dict, dictSize);
+    if (FSE_0_5_X_isError(matchlengthHeaderSize)) return ERROR(dictionary_corrupted);
+    errorCode = FSE_0_5_X_buildDTable(dctx->MLTable, matchlengthNCount, matchlengthMaxValue, matchlengthLog);
+    if (FSE_0_5_X_isError(errorCode)) return ERROR(dictionary_corrupted);
     dict = (const char*)dict + matchlengthHeaderSize;
     dictSize -= matchlengthHeaderSize;
 
-    litlengthHeaderSize = FSE_readNCount(litlengthNCount, &litlengthMaxValue, &litlengthLog, dict, dictSize);
-    if (FSE_isError(litlengthHeaderSize)) return ERROR(dictionary_corrupted);
-    errorCode = FSE_buildDTable(dctx->LLTable, litlengthNCount, litlengthMaxValue, litlengthLog);
-    if (FSE_isError(errorCode)) return ERROR(dictionary_corrupted);
+    litlengthHeaderSize = FSE_0_5_X_readNCount(litlengthNCount, &litlengthMaxValue, &litlengthLog, dict, dictSize);
+    if (FSE_0_5_X_isError(litlengthHeaderSize)) return ERROR(dictionary_corrupted);
+    errorCode = FSE_0_5_X_buildDTable(dctx->LLTable, litlengthNCount, litlengthMaxValue, litlengthLog);
+    if (FSE_0_5_X_isError(errorCode)) return ERROR(dictionary_corrupted);
 
     dctx->flagStaticTables = 1;
     return hSize + offcodeHeaderSize + matchlengthHeaderSize + litlengthHeaderSize;
 }
 
-static size_t ZSTD_decompress_insertDictionary(ZSTD_DCtx* dctx, const void* dict, size_t dictSize)
+static size_t ZSTD_0_5_X_decompress_insertDictionary(ZSTD_0_5_X_DCtx* dctx, const void* dict, size_t dictSize)
 {
     size_t eSize;
     U32 magic = MEM_readLE32(dict);
-    if (magic != ZSTD_DICT_MAGIC) {
+    if (magic != ZSTD_0_5_X_DICT_MAGIC) {
         /* pure content mode */
-        ZSTD_refDictContent(dctx, dict, dictSize);
+        ZSTD_0_5_X_refDictContent(dctx, dict, dictSize);
         return 0;
     }
     /* load entropy tables */
     dict = (const char*)dict + 4;
     dictSize -= 4;
-    eSize = ZSTD_loadEntropy(dctx, dict, dictSize);
-    if (ZSTD_isError(eSize)) return ERROR(dictionary_corrupted);
+    eSize = ZSTD_0_5_X_loadEntropy(dctx, dict, dictSize);
+    if (ZSTD_0_5_X_isError(eSize)) return ERROR(dictionary_corrupted);
 
     /* reference dictionary content */
     dict = (const char*)dict + eSize;
     dictSize -= eSize;
-    ZSTD_refDictContent(dctx, dict, dictSize);
+    ZSTD_0_5_X_refDictContent(dctx, dict, dictSize);
 
     return 0;
 }
 
 
-size_t ZSTD_decompressBegin_usingDict(ZSTD_DCtx* dctx, const void* dict, size_t dictSize)
+size_t ZSTD_0_5_X_decompressBegin_usingDict(ZSTD_0_5_X_DCtx* dctx, const void* dict, size_t dictSize)
 {
     size_t errorCode;
-    errorCode = ZSTD_decompressBegin(dctx);
-    if (ZSTD_isError(errorCode)) return errorCode;
+    errorCode = ZSTD_0_5_X_decompressBegin(dctx);
+    if (ZSTD_0_5_X_isError(errorCode)) return errorCode;
 
     if (dict && dictSize) {
-        errorCode = ZSTD_decompress_insertDictionary(dctx, dict, dictSize);
-        if (ZSTD_isError(errorCode)) return ERROR(dictionary_corrupted);
+        errorCode = ZSTD_0_5_X_decompress_insertDictionary(dctx, dict, dictSize);
+        if (ZSTD_0_5_X_isError(errorCode)) return ERROR(dictionary_corrupted);
     }
 
     return 0;

--- a/zstd_internal.h
+++ b/zstd_internal.h
@@ -29,8 +29,8 @@
     You can contact the author at :
     - zstd source repository : https://github.com/Cyan4973/zstd
 */
-#ifndef ZSTD_CCOMMON_H_MODULE
-#define ZSTD_CCOMMON_H_MODULE
+#ifndef ZSTD_0_5_X_CCOMMON_H_MODULE
+#define ZSTD_0_5_X_CCOMMON_H_MODULE
 
 #if defined (__cplusplus)
 extern "C" {
@@ -54,8 +54,8 @@ extern "C" {
 /* *************************************
 *  Common constants
 ***************************************/
-#define ZSTD_MAGICNUMBER 0xFD2FB525   /* v0.5 */
-#define ZSTD_DICT_MAGIC  0xEC30A435
+#define ZSTD_0_5_X_MAGICNUMBER 0xFD2FB525   /* v0.5 */
+#define ZSTD_0_5_X_DICT_MAGIC  0xEC30A435
 
 #define KB *(1 <<10)
 #define MB *(1 <<20)
@@ -63,9 +63,9 @@ extern "C" {
 
 #define BLOCKSIZE (128 KB)                 /* define, for static allocation */
 
-static const size_t ZSTD_blockHeaderSize = 3;
-static const size_t ZSTD_frameHeaderSize_min = 5;
-#define ZSTD_frameHeaderSize_max 5         /* define, for static allocation */
+static const size_t ZSTD_0_5_X_blockHeaderSize = 3;
+static const size_t ZSTD_0_5_X_frameHeaderSize_min = 5;
+#define ZSTD_0_5_X_frameHeaderSize_max 5         /* define, for static allocation */
 
 #define BIT7 128
 #define BIT6  64
@@ -93,10 +93,10 @@ static const size_t ZSTD_frameHeaderSize_min = 5;
 #define OffFSELog   9
 #define MaxSeq MAX(MaxLL, MaxML)
 
-#define FSE_ENCODING_RAW     0
-#define FSE_ENCODING_RLE     1
-#define FSE_ENCODING_STATIC  2
-#define FSE_ENCODING_DYNAMIC 3
+#define FSE_0_5_X_ENCODING_RAW     0
+#define FSE_0_5_X_ENCODING_RLE     1
+#define FSE_0_5_X_ENCODING_STATIC  2
+#define FSE_0_5_X_ENCODING_DYNAMIC 3
 
 
 #define HufLog 12
@@ -112,13 +112,13 @@ typedef enum { bt_compressed, bt_raw, bt_rle, bt_end } blockType_t;
 /*-*******************************************
 *  Shared functions to include for inlining
 *********************************************/
-static void ZSTD_copy8(void* dst, const void* src) { memcpy(dst, src, 8); }
+static void ZSTD_0_5_X_copy8(void* dst, const void* src) { memcpy(dst, src, 8); }
 
-#define COPY8(d,s) { ZSTD_copy8(d,s); d+=8; s+=8; }
+#define COPY8(d,s) { ZSTD_0_5_X_copy8(d,s); d+=8; s+=8; }
 
-/*! ZSTD_wildcopy() :
+/*! ZSTD_0_5_X_wildcopy() :
 *   custom version of memcpy(), can copy up to 7 bytes too many (8 bytes if length==0) */
-MEM_STATIC void ZSTD_wildcopy(void* dst, const void* src, size_t length)
+MEM_STATIC void ZSTD_0_5_X_wildcopy(void* dst, const void* src, size_t length)
 {
     const BYTE* ip = (const BYTE*)src;
     BYTE* op = (BYTE*)dst;
@@ -133,4 +133,4 @@ MEM_STATIC void ZSTD_wildcopy(void* dst, const void* src, size_t length)
 }
 #endif
 
-#endif   /* ZSTD_CCOMMON_H_MODULE */
+#endif   /* ZSTD_0_5_X_CCOMMON_H_MODULE */

--- a/zstd_static.h
+++ b/zstd_static.h
@@ -29,8 +29,8 @@
     You can contact the author at :
     - zstd source repository : https://github.com/Cyan4973/zstd
 */
-#ifndef ZSTD_STATIC_H
-#define ZSTD_STATIC_H
+#ifndef ZSTD_0_5_X_STATIC_H
+#define ZSTD_0_5_X_STATIC_H
 
 /* The objects defined into this file shall be considered experimental.
  * They are not considered stable, as their prototype may change in the future.
@@ -51,20 +51,20 @@ extern "C" {
 /*-*************************************
 *  Types
 ***************************************/
-#define ZSTD_WINDOWLOG_MAX 26
-#define ZSTD_WINDOWLOG_MIN 18
-#define ZSTD_WINDOWLOG_ABSOLUTEMIN 11
-#define ZSTD_CONTENTLOG_MAX (ZSTD_WINDOWLOG_MAX+1)
-#define ZSTD_CONTENTLOG_MIN 4
-#define ZSTD_HASHLOG_MAX 28
-#define ZSTD_HASHLOG_MIN 4
-#define ZSTD_SEARCHLOG_MAX (ZSTD_CONTENTLOG_MAX-1)
-#define ZSTD_SEARCHLOG_MIN 1
-#define ZSTD_SEARCHLENGTH_MAX 7
-#define ZSTD_SEARCHLENGTH_MIN 4
+#define ZSTD_0_5_X_WINDOWLOG_MAX 26
+#define ZSTD_0_5_X_WINDOWLOG_MIN 18
+#define ZSTD_0_5_X_WINDOWLOG_ABSOLUTEMIN 11
+#define ZSTD_0_5_X_CONTENTLOG_MAX (ZSTD_0_5_X_WINDOWLOG_MAX+1)
+#define ZSTD_0_5_X_CONTENTLOG_MIN 4
+#define ZSTD_0_5_X_HASHLOG_MAX 28
+#define ZSTD_0_5_X_HASHLOG_MIN 4
+#define ZSTD_0_5_X_SEARCHLOG_MAX (ZSTD_0_5_X_CONTENTLOG_MAX-1)
+#define ZSTD_0_5_X_SEARCHLOG_MIN 1
+#define ZSTD_0_5_X_SEARCHLENGTH_MAX 7
+#define ZSTD_0_5_X_SEARCHLENGTH_MIN 4
 
 /** from faster to stronger */
-typedef enum { ZSTD_fast, ZSTD_greedy, ZSTD_lazy, ZSTD_lazy2, ZSTD_btlazy2 } ZSTD_strategy;
+typedef enum { ZSTD_0_5_X_fast, ZSTD_0_5_X_greedy, ZSTD_0_5_X_lazy, ZSTD_0_5_X_lazy2, ZSTD_0_5_X_btlazy2 } ZSTD_0_5_X_strategy;
 
 typedef struct
 {
@@ -74,52 +74,52 @@ typedef struct
     uint32_t hashLog;       /* dispatch table : larger == more memory, faster */
     uint32_t searchLog;     /* nb of searches : larger == more compression, slower */
     uint32_t searchLength;  /* size of matches : larger == faster decompression, sometimes less compression */
-    ZSTD_strategy strategy;
-} ZSTD_parameters;
+    ZSTD_0_5_X_strategy strategy;
+} ZSTD_0_5_X_parameters;
 
 
 /* *************************************
 *  Advanced functions
 ***************************************/
-#define ZSTD_MAX_CLEVEL 20
-ZSTDLIB_API unsigned ZSTD_maxCLevel (void);
+#define ZSTD_0_5_X_MAX_CLEVEL 20
+ZSTDLIB_API unsigned ZSTD_0_5_X_maxCLevel (void);
 
-/*! ZSTD_getParams() :
-*   @return ZSTD_parameters structure for a selected compression level and srcSize.
+/*! ZSTD_0_5_X_getParams() :
+*   @return ZSTD_0_5_X_parameters structure for a selected compression level and srcSize.
 *   `srcSizeHint` value is optional, select 0 if not known */
-ZSTDLIB_API ZSTD_parameters ZSTD_getParams(int compressionLevel, U64 srcSizeHint);
+ZSTDLIB_API ZSTD_0_5_X_parameters ZSTD_0_5_X_getParams(int compressionLevel, U64 srcSizeHint);
 
-/*! ZSTD_validateParams() :
+/*! ZSTD_0_5_X_validateParams() :
 *   correct params value to remain within authorized range */
-ZSTDLIB_API void ZSTD_validateParams(ZSTD_parameters* params);
+ZSTDLIB_API void ZSTD_0_5_X_validateParams(ZSTD_0_5_X_parameters* params);
 
-/*! ZSTD_compress_advanced() :
-*   Same as ZSTD_compress_usingDict(), with fine-tune control of each compression parameter */
-ZSTDLIB_API size_t ZSTD_compress_advanced (ZSTD_CCtx* ctx,
+/*! ZSTD_0_5_X_compress_advanced() :
+*   Same as ZSTD_0_5_X_compress_usingDict(), with fine-tune control of each compression parameter */
+ZSTDLIB_API size_t ZSTD_0_5_X_compress_advanced (ZSTD_0_5_X_CCtx* ctx,
                                            void* dst, size_t dstCapacity,
                                      const void* src, size_t srcSize,
                                      const void* dict,size_t dictSize,
-                                           ZSTD_parameters params);
+                                           ZSTD_0_5_X_parameters params);
 
-/*! ZSTD_compress_usingPreparedDCtx() :
-*   Same as ZSTD_compress_usingDict, but using a reference context `preparedCCtx`, where dictionary has been loaded.
+/*! ZSTD_0_5_X_compress_usingPreparedDCtx() :
+*   Same as ZSTD_0_5_X_compress_usingDict, but using a reference context `preparedCCtx`, where dictionary has been loaded.
 *   It avoids reloading the dictionary each time.
-*   `preparedCCtx` must have been properly initialized using ZSTD_compressBegin_usingDict() or ZSTD_compressBegin_advanced().
+*   `preparedCCtx` must have been properly initialized using ZSTD_0_5_X_compressBegin_usingDict() or ZSTD_0_5_X_compressBegin_advanced().
 *   Requires 2 contexts : 1 for reference, which will not be modified, and 1 to run the compression operation */
-ZSTDLIB_API size_t ZSTD_compress_usingPreparedCCtx(
-                                           ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx,
+ZSTDLIB_API size_t ZSTD_0_5_X_compress_usingPreparedCCtx(
+                                           ZSTD_0_5_X_CCtx* cctx, const ZSTD_0_5_X_CCtx* preparedCCtx,
                                            void* dst, size_t dstCapacity,
                                      const void* src, size_t srcSize);
 
 /*- Advanced Decompression functions -*/
 
-/*! ZSTD_decompress_usingPreparedDCtx() :
-*   Same as ZSTD_decompress_usingDict, but using a reference context `preparedDCtx`, where dictionary has been loaded.
+/*! ZSTD_0_5_X_decompress_usingPreparedDCtx() :
+*   Same as ZSTD_0_5_X_decompress_usingDict, but using a reference context `preparedDCtx`, where dictionary has been loaded.
 *   It avoids reloading the dictionary each time.
-*   `preparedDCtx` must have been properly initialized using ZSTD_decompressBegin_usingDict().
+*   `preparedDCtx` must have been properly initialized using ZSTD_0_5_X_decompressBegin_usingDict().
 *   Requires 2 contexts : 1 for reference, which will not be modified, and 1 to run the decompression operation */
-ZSTDLIB_API size_t ZSTD_decompress_usingPreparedDCtx(
-                                             ZSTD_DCtx* dctx, const ZSTD_DCtx* preparedDCtx,
+ZSTDLIB_API size_t ZSTD_0_5_X_decompress_usingPreparedDCtx(
+                                             ZSTD_0_5_X_DCtx* dctx, const ZSTD_0_5_X_DCtx* preparedDCtx,
                                              void* dst, size_t dstCapacity,
                                        const void* src, size_t srcSize);
 
@@ -127,74 +127,74 @@ ZSTDLIB_API size_t ZSTD_decompress_usingPreparedDCtx(
 /* **************************************
 *  Streaming functions (direct mode)
 ****************************************/
-ZSTDLIB_API size_t ZSTD_compressBegin(ZSTD_CCtx* cctx, int compressionLevel);
-ZSTDLIB_API size_t ZSTD_compressBegin_usingDict(ZSTD_CCtx* cctx, const void* dict,size_t dictSize, int compressionLevel);
-ZSTDLIB_API size_t ZSTD_compressBegin_advanced(ZSTD_CCtx* cctx, const void* dict,size_t dictSize, ZSTD_parameters params);
-ZSTDLIB_API size_t ZSTD_copyCCtx(ZSTD_CCtx* cctx, const ZSTD_CCtx* preparedCCtx);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressBegin(ZSTD_0_5_X_CCtx* cctx, int compressionLevel);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressBegin_usingDict(ZSTD_0_5_X_CCtx* cctx, const void* dict,size_t dictSize, int compressionLevel);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressBegin_advanced(ZSTD_0_5_X_CCtx* cctx, const void* dict,size_t dictSize, ZSTD_0_5_X_parameters params);
+ZSTDLIB_API size_t ZSTD_0_5_X_copyCCtx(ZSTD_0_5_X_CCtx* cctx, const ZSTD_0_5_X_CCtx* preparedCCtx);
 
-ZSTDLIB_API size_t ZSTD_compressContinue(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
-ZSTDLIB_API size_t ZSTD_compressEnd(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressContinue(ZSTD_0_5_X_CCtx* cctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_0_5_X_compressEnd(ZSTD_0_5_X_CCtx* cctx, void* dst, size_t dstCapacity);
 
 /*
   Streaming compression, synchronous mode (bufferless)
 
-  A ZSTD_CCtx object is required to track streaming operations.
-  Use ZSTD_createCCtx() / ZSTD_freeCCtx() to manage it.
-  ZSTD_CCtx object can be re-used multiple times within successive compression operations.
+  A ZSTD_0_5_X_CCtx object is required to track streaming operations.
+  Use ZSTD_0_5_X_createCCtx() / ZSTD_0_5_X_freeCCtx() to manage it.
+  ZSTD_0_5_X_CCtx object can be re-used multiple times within successive compression operations.
 
   Start by initializing a context.
-  Use ZSTD_compressBegin(), or ZSTD_compressBegin_usingDict() for dictionary compression,
-  or ZSTD_compressBegin_advanced(), for finer parameter control.
-  It's also possible to duplicate a reference context which has been initialized, using ZSTD_copyCCtx()
+  Use ZSTD_0_5_X_compressBegin(), or ZSTD_0_5_X_compressBegin_usingDict() for dictionary compression,
+  or ZSTD_0_5_X_compressBegin_advanced(), for finer parameter control.
+  It's also possible to duplicate a reference context which has been initialized, using ZSTD_0_5_X_copyCCtx()
 
-  Then, consume your input using ZSTD_compressContinue().
+  Then, consume your input using ZSTD_0_5_X_compressContinue().
   The interface is synchronous, so all input will be consumed and produce a compressed output.
   You must ensure there is enough space in destination buffer to store compressed data under worst case scenario.
-  Worst case evaluation is provided by ZSTD_compressBound().
+  Worst case evaluation is provided by ZSTD_0_5_X_compressBound().
 
-  Finish a frame with ZSTD_compressEnd(), which will write the epilogue.
+  Finish a frame with ZSTD_0_5_X_compressEnd(), which will write the epilogue.
   Without the epilogue, frames will be considered incomplete by decoder.
 
-  You can then reuse ZSTD_CCtx to compress some new frame.
+  You can then reuse ZSTD_0_5_X_CCtx to compress some new frame.
 */
 
 
-ZSTDLIB_API size_t ZSTD_decompressBegin(ZSTD_DCtx* dctx);
-ZSTDLIB_API size_t ZSTD_decompressBegin_usingDict(ZSTD_DCtx* dctx, const void* dict, size_t dictSize);
-ZSTDLIB_API void   ZSTD_copyDCtx(ZSTD_DCtx* dctx, const ZSTD_DCtx* preparedDCtx);
+ZSTDLIB_API size_t ZSTD_0_5_X_decompressBegin(ZSTD_0_5_X_DCtx* dctx);
+ZSTDLIB_API size_t ZSTD_0_5_X_decompressBegin_usingDict(ZSTD_0_5_X_DCtx* dctx, const void* dict, size_t dictSize);
+ZSTDLIB_API void   ZSTD_0_5_X_copyDCtx(ZSTD_0_5_X_DCtx* dctx, const ZSTD_0_5_X_DCtx* preparedDCtx);
 
-ZSTDLIB_API size_t ZSTD_getFrameParams(ZSTD_parameters* params, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_0_5_X_getFrameParams(ZSTD_0_5_X_parameters* params, const void* src, size_t srcSize);
 
-ZSTDLIB_API size_t ZSTD_nextSrcSizeToDecompress(ZSTD_DCtx* dctx);
-ZSTDLIB_API size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
+ZSTDLIB_API size_t ZSTD_0_5_X_nextSrcSizeToDecompress(ZSTD_0_5_X_DCtx* dctx);
+ZSTDLIB_API size_t ZSTD_0_5_X_decompressContinue(ZSTD_0_5_X_DCtx* dctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 
 /*
   Streaming decompression, direct mode (bufferless)
 
-  A ZSTD_DCtx object is required to track streaming operations.
-  Use ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.
-  A ZSTD_DCtx object can be re-used multiple times.
+  A ZSTD_0_5_X_DCtx object is required to track streaming operations.
+  Use ZSTD_0_5_X_createDCtx() / ZSTD_0_5_X_freeDCtx() to manage it.
+  A ZSTD_0_5_X_DCtx object can be re-used multiple times.
 
-  First typical operation is to retrieve frame parameters, using ZSTD_getFrameParams().
+  First typical operation is to retrieve frame parameters, using ZSTD_0_5_X_getFrameParams().
   This operation is independent, and just needs enough input data to properly decode the frame header.
   Objective is to retrieve *params.windowlog, to know minimum amount of memory required during decoding.
-  Result : 0 when successful, it means the ZSTD_parameters structure has been filled.
+  Result : 0 when successful, it means the ZSTD_0_5_X_parameters structure has been filled.
            >0 : means there is not enough data into src. Provides the expected size to successfully decode header.
-           errorCode, which can be tested using ZSTD_isError()
+           errorCode, which can be tested using ZSTD_0_5_X_isError()
 
-  Start decompression, with ZSTD_decompressBegin() or ZSTD_decompressBegin_usingDict()
-  Alternatively, you can copy a prepared context, using ZSTD_copyDCtx()
+  Start decompression, with ZSTD_0_5_X_decompressBegin() or ZSTD_0_5_X_decompressBegin_usingDict()
+  Alternatively, you can copy a prepared context, using ZSTD_0_5_X_copyDCtx()
 
-  Then use ZSTD_nextSrcSizeToDecompress() and ZSTD_decompressContinue() alternatively.
-  ZSTD_nextSrcSizeToDecompress() tells how much bytes to provide as 'srcSize' to ZSTD_decompressContinue().
-  ZSTD_decompressContinue() requires this exact amount of bytes, or it will fail.
-  ZSTD_decompressContinue() needs previous data blocks during decompression, up to (1 << windowlog).
+  Then use ZSTD_0_5_X_nextSrcSizeToDecompress() and ZSTD_0_5_X_decompressContinue() alternatively.
+  ZSTD_0_5_X_nextSrcSizeToDecompress() tells how much bytes to provide as 'srcSize' to ZSTD_0_5_X_decompressContinue().
+  ZSTD_0_5_X_decompressContinue() requires this exact amount of bytes, or it will fail.
+  ZSTD_0_5_X_decompressContinue() needs previous data blocks during decompression, up to (1 << windowlog).
   They should preferably be located contiguously, prior to current block. Alternatively, a round buffer is also possible.
 
-  @result of ZSTD_decompressContinue() is the number of bytes regenerated within 'dst'.
-  It can be zero, which is not an error; it just means ZSTD_decompressContinue() has decoded some header.
+  @result of ZSTD_0_5_X_decompressContinue() is the number of bytes regenerated within 'dst'.
+  It can be zero, which is not an error; it just means ZSTD_0_5_X_decompressContinue() has decoded some header.
 
-  A frame is fully decoded when ZSTD_nextSrcSizeToDecompress() returns zero.
+  A frame is fully decoded when ZSTD_0_5_X_nextSrcSizeToDecompress() returns zero.
   Context can then be reset to start a new decompression.
 */
 
@@ -208,34 +208,34 @@ ZSTDLIB_API size_t ZSTD_decompressContinue(ZSTD_DCtx* dctx, void* dst, size_t ds
     A few rules to respect :
     - Uncompressed block size must be <= 128 KB
     - Compressing or decompressing requires a context structure
-      + Use ZSTD_createCCtx() and ZSTD_createDCtx()
+      + Use ZSTD_0_5_X_createCCtx() and ZSTD_0_5_X_createDCtx()
     - It is necessary to init context before starting
-      + compression : ZSTD_compressBegin()
-      + decompression : ZSTD_decompressBegin()
+      + compression : ZSTD_0_5_X_compressBegin()
+      + decompression : ZSTD_0_5_X_decompressBegin()
       + variants _usingDict() are also allowed
       + copyCCtx() and copyDCtx() work too
-    - When a block is considered not compressible enough, ZSTD_compressBlock() result will be zero.
+    - When a block is considered not compressible enough, ZSTD_0_5_X_compressBlock() result will be zero.
       In which case, nothing is produced into `dst`.
       + User must test for such outcome and deal directly with uncompressed data
-      + ZSTD_decompressBlock() doesn't accept uncompressed data as input !!
+      + ZSTD_0_5_X_decompressBlock() doesn't accept uncompressed data as input !!
 */
 
-size_t ZSTD_compressBlock  (ZSTD_CCtx* cctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
-size_t ZSTD_decompressBlock(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
+size_t ZSTD_0_5_X_compressBlock  (ZSTD_0_5_X_CCtx* cctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
+size_t ZSTD_0_5_X_decompressBlock(ZSTD_0_5_X_DCtx* dctx, void* dst, size_t dstCapacity, const void* src, size_t srcSize);
 
 
 /* *************************************
 *  Error management
 ***************************************/
 #include "error_public.h"
-/*! ZSTD_getErrorCode() :
-    convert a `size_t` function result into a `ZSTD_error_code` enum type,
+/*! ZSTD_0_5_X_getErrorCode() :
+    convert a `size_t` function result into a `ZSTD_0_5_X_error_code` enum type,
     which can be used to compare directly with enum list within "error_public.h" */
-ZSTD_ErrorCode ZSTD_getError(size_t code);
+ZSTD_0_5_X_ErrorCode ZSTD_0_5_X_getError(size_t code);
 
 
 #if defined (__cplusplus)
 }
 #endif
 
-#endif  /* ZSTD_STATIC_H */
+#endif  /* ZSTD_0_5_X_STATIC_H */

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -1,4 +1,4 @@
-package zstd
+package zstd_0_5_x
 
 /*
 #include "zstd.h"
@@ -16,7 +16,7 @@ import (
 type Writer struct {
 	CompressionLevel int
 
-	ctx              *C.ZSTD_CCtx
+	ctx              *C.ZSTD_0_5_X_CCtx
 	dict             []byte
 	dstBuffer        []byte
 	firstError       error
@@ -55,13 +55,13 @@ func NewWriterLevel(w io.Writer, level int) *Writer {
 // should not be modified until the writer is closed.
 func NewWriterLevelDict(w io.Writer, level int, dict []byte) *Writer {
 	var err error
-	ctx := C.ZSTD_createCCtx()
+	ctx := C.ZSTD_0_5_X_createCCtx()
 
 	if dict == nil {
-		err = getError(int(C.ZSTD_compressBegin(ctx,
+		err = getError(int(C.ZSTD_0_5_X_compressBegin(ctx,
 			C.int(level))))
 	} else {
-		err = getError(int(C.ZSTD_compressBegin_usingDict(
+		err = getError(int(C.ZSTD_0_5_X_compressBegin_usingDict(
 			ctx,
 			unsafe.Pointer(&dict[0]),
 			C.size_t(len(dict)),
@@ -91,7 +91,7 @@ func (w *Writer) Write(p []byte) (int, error) {
 		w.dstBuffer = make([]byte, CompressBound(len(p)))
 	}
 
-	retCode := C.ZSTD_compressContinue(
+	retCode := C.ZSTD_0_5_X_compressContinue(
 		w.ctx,
 		unsafe.Pointer(&w.dstBuffer[0]),
 		C.size_t(len(w.dstBuffer)),
@@ -117,7 +117,7 @@ func (w *Writer) Write(p []byte) (int, error) {
 // Close closes the Writer, flushing any unwritten data to the underlying
 // io.Writer and freeing objects, but does not close the underlying io.Writer.
 func (w *Writer) Close() error {
-	retCode := C.ZSTD_compressEnd(
+	retCode := C.ZSTD_0_5_X_compressEnd(
 		w.ctx,
 		unsafe.Pointer(&w.dstBuffer[0]),
 		C.size_t(len(w.dstBuffer)))
@@ -126,7 +126,7 @@ func (w *Writer) Close() error {
 		return err
 	}
 	written := int(retCode)
-	retCode = C.ZSTD_freeCCtx(w.ctx) // Safely close buffer before writing the end
+	retCode = C.ZSTD_0_5_X_freeCCtx(w.ctx) // Safely close buffer before writing the end
 
 	if err := getError(int(retCode)); err != nil {
 		return err
@@ -141,7 +141,7 @@ func (w *Writer) Close() error {
 
 // reader is an io.ReadCloser that decompresses when read from.
 type reader struct {
-	ctx                 *C.ZBUFF_DCtx
+	ctx                 *C.ZBUFF_0_5_X_DCtx
 	compressionBuffer   []byte
 	decompressionBuffer []byte
 	dict                []byte
@@ -166,22 +166,22 @@ func NewReader(r io.Reader) io.ReadCloser {
 // ignores the dictionary if it is nil.
 func NewReaderDict(r io.Reader, dict []byte) io.ReadCloser {
 	var err error
-	ctx := C.ZBUFF_createDCtx()
+	ctx := C.ZBUFF_0_5_X_createDCtx()
 	if len(dict) == 0 {
-		err = getError(int(C.ZBUFF_decompressInit(ctx)))
+		err = getError(int(C.ZBUFF_0_5_X_decompressInit(ctx)))
 	} else {
-		err = getError(int(C.ZBUFF_decompressInitDictionary(
+		err = getError(int(C.ZBUFF_0_5_X_decompressInitDictionary(
 			ctx,
 			unsafe.Pointer(&dict[0]),
 			C.size_t(len(dict)))))
 	}
-	cSize := int(C.ZBUFF_recommendedDInSize())
-	dSize := int(C.ZBUFF_recommendedDOutSize())
+	cSize := int(C.ZBUFF_0_5_X_recommendedDInSize())
+	dSize := int(C.ZBUFF_0_5_X_recommendedDOutSize())
 	if cSize <= 0 {
-		panic(fmt.Errorf("ZBUFF_recommendedDInSize() returned invalid size: %v", cSize))
+		panic(fmt.Errorf("ZBUFF_0_5_X_recommendedDInSize() returned invalid size: %v", cSize))
 	}
 	if dSize <= 0 {
-		panic(fmt.Errorf("ZBUFF_recommendedDOutSize() returned invalid size: %v", dSize))
+		panic(fmt.Errorf("ZBUFF_0_5_X_recommendedDOutSize() returned invalid size: %v", dSize))
 	}
 
 	compressionBuffer := make([]byte, cSize)
@@ -199,7 +199,7 @@ func NewReaderDict(r io.Reader, dict []byte) io.ReadCloser {
 
 // Close frees the allocated C objects
 func (r *reader) Close() error {
-	return getError(int(C.ZBUFF_freeDCtx(r.ctx)))
+	return getError(int(C.ZBUFF_0_5_X_freeDCtx(r.ctx)))
 }
 
 func (r *reader) Read(p []byte) (int, error) {
@@ -227,7 +227,7 @@ func (r *reader) Read(p []byte) (int, error) {
 		// C code
 		cSrcSize := C.size_t(len(src))
 		cDstSize := C.size_t(len(r.decompressionBuffer))
-		retCode := int(C.ZBUFF_decompressContinue(
+		retCode := int(C.ZBUFF_0_5_X_decompressContinue(
 			r.ctx,
 			unsafe.Pointer(&r.decompressionBuffer[0]),
 			&cDstSize,

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -1,4 +1,4 @@
-package zstd_0_5_x
+package zstd_0
 
 /*
 #include "zstd.h"

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -1,4 +1,4 @@
-package zstd
+package zstd_0_5_x
 
 import (
 	"bytes"

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -1,4 +1,4 @@
-package zstd_0_5_x
+package zstd_0
 
 import (
 	"bytes"

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -1,4 +1,4 @@
-package zstd
+package zstd_0_5_x
 
 import (
 	"bytes"

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -1,4 +1,4 @@
-package zstd_0_5_x
+package zstd_0
 
 import (
 	"bytes"


### PR DESCRIPTION
```
gsed -i -r 's/ZSTD_/ZSTD_0_5_X_/g' *.c *.go *.h
gsed -i -r 's/package zstd/package zstd_0/g' *.c *.go *.h
gsed -i -r 's/FSE_/FSE_0_5_X_/g' *.c *.go *.h
gsed -i -r 's/HUF_/HUF_0_5_X_/g' *.c *.go *.h
gsed -i -r 's/ZBUFF_/ZBUFF_0_5_X_/g' *.c *.go *.h
gsed -i -r 's/divsufsort\(/divsufsort_0_5_x(/g' *.c *.go *.h
gsed -i -r 's/divbwt\(/divbwt_0_5_x(/g' *.c *.go *.h

... and a few others
```